### PR TITLE
feat: allow patches to replace existing attributes

### DIFF
--- a/app/docs/API_GUIDE.md
+++ b/app/docs/API_GUIDE.md
@@ -179,7 +179,8 @@ the same name.
 As part of allowing filemanager to link and query on attributes, attributes can be updated using PATCH requests.
 Each of the above endpoints and queries supports a PATCH request which can be used to update attributes on a set
 of records, instead of listing records. All query parameters except pagination are supported for updates.
-Attributes are update using [JSON patch][json-patch].
+Attributes are update using [JSON patch][json-patch]. To update attributes, the patch operation must be `add`, `test`,
+or `copy`, noting that `add` is able to replace existing attributes.
 
 For example, update attributes on a single record:
 

--- a/app/docs/API_GUIDE.md
+++ b/app/docs/API_GUIDE.md
@@ -179,7 +179,7 @@ the same name.
 As part of allowing filemanager to link and query on attributes, attributes can be updated using PATCH requests.
 Each of the above endpoints and queries supports a PATCH request which can be used to update attributes on a set
 of records, instead of listing records. All query parameters except pagination are supported for updates.
-Attributes are update using [JSON patch][json-patch]. To update attributes, the patch operation must be `add`, `test`,
+Attributes are updated using [JSON patch][json-patch]. To update attributes, the patch operation must be `add`, `test`,
 or `copy`, noting that `add` is able to replace existing attributes.
 
 For example, update attributes on a single record:

--- a/app/filemanager/src/routes/crawl.rs
+++ b/app/filemanager/src/routes/crawl.rs
@@ -32,7 +32,6 @@ use sea_orm::ActiveValue::Set;
 use sea_orm::{ActiveModelTrait, ConnectionTrait, EntityTrait, IntoActiveModel, TransactionTrait};
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
-use std::ops::Deref;
 use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 

--- a/app/filemanager/src/routes/update.rs
+++ b/app/filemanager/src/routes/update.rs
@@ -22,8 +22,8 @@ use crate::routes::AppState;
 ///
 /// In order to apply the patch, JSON body must contain an array with patch operations. The patch operations
 /// are append-only, which means that only "add", "copy" and "test" is supported. If a "test" check fails,
-/// a patch operations that isn't "add" or "test" is used, a `BAD_REQUEST` is returned and no records
-/// are updated. Note, that "add" is allowed to replace existing paths in the attributes. Use
+/// a patch operations that isn't "add", "copy" or "test" is used, a `BAD_REQUEST` is returned and no
+/// records are updated. Note, that "add" is allowed to replace existing paths in the attributes. Use
 /// `attributes` to update attributes and `ingestId` to update the ingest id.
 #[derive(Debug, Deserialize, Clone, ToSchema)]
 #[serde(untagged)]

--- a/app/filemanager/src/routes/update.rs
+++ b/app/filemanager/src/routes/update.rs
@@ -21,10 +21,10 @@ use crate::routes::AppState;
 /// See [JSON patch](https://jsonpatch.com/) and [RFC6902](https://datatracker.ietf.org/doc/html/rfc6902/).
 ///
 /// In order to apply the patch, JSON body must contain an array with patch operations. The patch operations
-/// are append-only, which means that only "add" and "test" is supported. If a "test" check fails,
-/// a patch operations that isn't "add" or "test" is used, or if a key already exists, a `BAD_REQUEST`
-/// is returned and no records are updated. Use `attributes` to update attributes and `ingestId` to
-/// update the ingest id.
+/// are append-only, which means that only "add", "copy" and "test" is supported. If a "test" check fails,
+/// a patch operations that isn't "add" or "test" is used, a `BAD_REQUEST` is returned and no records
+/// are updated. Note, that "add" is allowed to replace existing paths in the attributes. Use
+/// `attributes` to update attributes and `ingestId` to update the ingest id.
 #[derive(Debug, Deserialize, Clone, ToSchema)]
 #[serde(untagged)]
 #[schema(


### PR DESCRIPTION
Closes #12 

### Changes
* Allows the `add` and `copy` patch request to replace existing attributes.

Related to #5. This change makes it easier to update attributes in case something goes wrong with the annotator. 