### PR TITLE
fix: add alarm for oldest message

### DIFF
--- a/infrastructure/stage/filemanager-stateful-stack.ts
+++ b/infrastructure/stage/filemanager-stateful-stack.ts
@@ -61,15 +61,18 @@ export class FileManagerStatefulStack extends Stack {
 
     this.accessKeySecret = new AccessKeySecret(this, 'AccessKey', props.accessKeyProps);
 
+    const alarmOldestMessage = Duration.days(2).toSeconds();
     this.monitoredQueue = new MonitoredQueue(this, 'MonitoredQueue', {
       queueProps: {
         queueName: FILEMANAGER_INGEST_QUEUE,
         removalPolicy: RemovalPolicy.RETAIN,
+        alarmOldestMessageSeconds: alarmOldestMessage,
       },
       dlqProps: {
         queueName: `${FILEMANAGER_INGEST_QUEUE}-dlq`,
         removalPolicy: RemovalPolicy.RETAIN,
         retentionPeriod: Duration.days(14),
+        alarmOldestMessageSeconds: alarmOldestMessage,
       },
       snsTopicArn: SlackAlerts.formatArn(this),
     });

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript-eslint": "^8.34.1"
   },
   "dependencies": {
-    "@orcabus/platform-cdk-constructs": "^0.0.25",
+    "@orcabus/platform-cdk-constructs": "^0.0.32",
     "aws-cdk-lib": "^2.202.0",
     "cargo-lambda-cdk": "^0.0.33",
     "constructs": "^10.4.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@orcabus/platform-cdk-constructs':
-        specifier: ^0.0.25
-        version: 0.0.25(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.202.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.202.0(constructs@10.4.2))(constructs@10.4.2)
+        specifier: ^0.0.32
+        version: 0.0.32(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.202.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.202.0(constructs@10.4.2))(constructs@10.4.2)
       aws-cdk-lib:
         specifier: ^2.202.0
         version: 2.202.0(constructs@10.4.2)
@@ -580,8 +580,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@orcabus/platform-cdk-constructs@0.0.25':
-    resolution: {integrity: sha512-OG8riYfbdCGzXrLvJQsyVXxZQPtFB2uMt/9OPCO7SrYO7+ssCghHtvY47zVX4zID5sllzCdeN4Z/vrgFoJho8Q==}
+  '@orcabus/platform-cdk-constructs@0.0.32':
+    resolution: {integrity: sha512-y/dIC0Vbni29LcmBDTGJdPkgLv6tky8+1JDKV3Y2BhJ7Bg4uKlgXN+2u0FVfAuZErbXh8o+ebrTo1Td5mNSpOw==}
     peerDependencies:
       '@aws-cdk/aws-lambda-python-alpha': ^2.195.0-alpha.0
       aws-cdk-lib: ^2.195.0
@@ -3089,7 +3089,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@orcabus/platform-cdk-constructs@0.0.25(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.202.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.202.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@orcabus/platform-cdk-constructs@0.0.32(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.202.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.202.0(constructs@10.4.2))(constructs@10.4.2)':
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha': 2.195.0-alpha.0(aws-cdk-lib@2.202.0(constructs@10.4.2))(constructs@10.4.2)
       aws-cdk-lib: 2.202.0(constructs@10.4.2)


### PR DESCRIPTION
Closes #35 

### Changes
* Updates platform-cdk-constructs and adds alarm when the age of the oldest message is greater than 2 days.