### PR TITLE
feat: increase Lambda memory

### DIFF
--- a/infrastructure/stage/functions/function.ts
+++ b/infrastructure/stage/functions/function.ts
@@ -115,7 +115,7 @@ export class Function extends Construct {
           cargoLambdaFlags: ['--compiler', 'cargo'],
         }),
       },
-      memorySize: 128,
+      memorySize: 1024,
       timeout: props.timeout ?? Duration.seconds(28),
       environment: {
         // No password here, using RDS IAM to generate credentials.


### PR DESCRIPTION
Closes #41 

### Changes
* Increases Lambda memory to 1024 MB. This results in an increase in speed from improved cold start times while not increasing cost too greatly.