### PR TITLE
build: remove zig installation

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -78,7 +78,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      - uses: mlugg/setup-zig@v2
       - run: curl -fsSL https://cargo-lambda.info/install.sh | sh
 
       - uses: pnpm/action-setup@v4

--- a/infrastructure/stage/functions/function.ts
+++ b/infrastructure/stage/functions/function.ts
@@ -6,7 +6,6 @@ import { ManagedPolicy, PolicyStatement, Role } from 'aws-cdk-lib/aws-iam';
 import { RustFunction } from 'cargo-lambda-cdk';
 import path from 'path';
 import { FILEMANAGER_SERVICE_NAME, RDS_POLICY_NAME } from '../constants';
-import { spawnSync } from 'node:child_process';
 import { NamedLambdaRole } from '@orcabus/platform-cdk-constructs/named-lambda-role';
 
 /**
@@ -98,12 +97,6 @@ export class Function extends Construct {
     });
 
     const manifestPath = path.join(__dirname, '..', '..', '..', 'app');
-    const defaultTarget = spawnSync('rustc', ['--version', '--verbose'])
-      .stdout.toString()
-      .split(/\r?\n/)
-      .find((line) => line.startsWith('host:'))
-      ?.replace('host:', '')
-      .trim();
     this._function = new RustFunction(this, 'RustFunction', {
       manifestPath: manifestPath,
       binaryName: props.package,
@@ -111,9 +104,7 @@ export class Function extends Construct {
         environment: {
           ...props.buildEnvironment,
         },
-        ...(defaultTarget === 'aarch64-unknown-linux-gnu' && {
-          cargoLambdaFlags: ['--compiler', 'cargo'],
-        }),
+        cargoLambdaFlags: ['--compiler', 'cargo'],
       },
       memorySize: 1024,
       timeout: props.timeout ?? Duration.seconds(28),

--- a/infrastructure/toolchain/stateless-stack.ts
+++ b/infrastructure/toolchain/stateless-stack.ts
@@ -52,7 +52,6 @@ export class StatelessStack extends cdk.Stack {
               "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y",
               'source $HOME/.cargo/env',
               'rustup component add rustfmt',
-              'npm install -g @ziglang/cli',
               'curl -fsSL https://cargo-lambda.info/install.sh | sh',
             ],
           },


### PR DESCRIPTION
### Changes
*  Remove zig installation as it's unused when compiling to the same architecture.