### PR TITLE
fix: crawl deleted objects

### DIFF
--- a/app/filemanager-build/src/error.rs
+++ b/app/filemanager-build/src/error.rs
@@ -1,3 +1,5 @@
+#![allow(unused_assignments)]
+
 //! This module contains the crate's error types.
 //!
 
@@ -6,7 +8,7 @@ use std::fs::read_to_string;
 use std::panic::Location;
 use std::{fmt, io, result};
 
-use miette::{Diagnostic, NamedSource, SourceOffset, diagnostic};
+use miette::{Diagnostic, NamedSource, SourceOffset};
 use thiserror::Error;
 
 use crate::error::ErrorKind::IoError;

--- a/app/filemanager-build/src/gen_entities.rs
+++ b/app/filemanager-build/src/gen_entities.rs
@@ -25,7 +25,7 @@ pub async fn generate_entities(
         "--with-serde",
         "both",
         "--enum-extra-derives",
-        "strum::FromRepr, strum::EnumCount, sqlx::Decode, sqlx::Encode",
+        "strum::FromRepr, strum::EnumCount, sqlx::Decode, sqlx::Encode, Hash",
         "--model-extra-derives",
         "utoipa::ToSchema",
         "--model-extra-attributes",

--- a/app/filemanager/src/database/entities/sea_orm_active_enums.rs
+++ b/app/filemanager/src/database/entities/sea_orm_active_enums.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
     strum::EnumCount,
     sqlx::Decode,
     sqlx::Encode,
+    Hash,
     utoipa::ToSchema,
 )]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "archive_status")]
@@ -36,6 +37,7 @@ pub enum ArchiveStatus {
     strum::EnumCount,
     sqlx::Decode,
     sqlx::Encode,
+    Hash,
     utoipa::ToSchema,
 )]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "crawl_status")]
@@ -60,6 +62,7 @@ pub enum CrawlStatus {
     strum::EnumCount,
     sqlx::Decode,
     sqlx::Encode,
+    Hash,
     utoipa::ToSchema,
 )]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "event_type")]
@@ -84,6 +87,7 @@ pub enum EventType {
     strum::EnumCount,
     sqlx::Decode,
     sqlx::Encode,
+    Hash,
     utoipa::ToSchema,
 )]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "reason")]
@@ -126,6 +130,7 @@ pub enum Reason {
     strum::EnumCount,
     sqlx::Decode,
     sqlx::Encode,
+    Hash,
     utoipa::ToSchema,
 )]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "storage_class")]

--- a/app/filemanager/src/error.rs
+++ b/app/filemanager/src/error.rs
@@ -35,9 +35,9 @@ pub enum Error {
     S3Error(String),
     #[error("{0}")]
     IoError(#[from] io::Error),
-    #[error("numerical operation overflowed")]
+    #[error("operation overflowed")]
     OverflowError,
-    #[error("numerical conversion failed: `{0}`")]
+    #[error("conversion failed: `{0}`")]
     ConversionError(String),
     #[error("query error: `{0}`")]
     QueryError(String),

--- a/app/filemanager/src/events/aws/collecter.rs
+++ b/app/filemanager/src/events/aws/collecter.rs
@@ -441,14 +441,14 @@ impl<'a> Collecter<'a> {
                         bucket: Wildcard::new(crawl_bucket).into(),
                         key: Wildcard::new(format!(
                             "{}{}",
-                            crawl_prefix.unwrap_or_default().clone(),
+                            crawl_prefix.unwrap_or_default(),
                             "*"
                         ))
                         .into(),
                         ..Default::default()
                     },
                     true,
-                    true,
+                    false,
                 )?
                 .all()
                 .await?
@@ -476,7 +476,7 @@ impl<'a> Collecter<'a> {
         let (always_update, s3_state): (HashSet<_>, HashSet<_>) =
             s3_state.into_iter().partition(|state| {
                 null_sequencer.iter().any(|database| {
-                    database.0.key == state.0.key && database.0.bucket == state.0.bucket
+                    database.0.key == state.0.key && database.0.bucket == state.0.bucket && database.0.version_id == state.0.version_id
                 })
             });
 

--- a/app/filemanager/src/events/aws/crawl.rs
+++ b/app/filemanager/src/events/aws/crawl.rs
@@ -527,6 +527,27 @@ pub(crate) mod tests {
             archive_status: Set(Some(ArchiveStatus::DeepArchiveAccess)),
             e_tag: Set(Some(EXPECTED_QUOTED_E_TAG.to_string())),
             last_modified_date: Set(Some("1970-01-01 00:00:00.000000 +00:00".parse().unwrap())),
+            version_id: Set("old_version_id".to_string()),
+            size: Set(Some(1)),
+            is_current_state: Set(true),
+            sha256: Set(Some(EXPECTED_SHA256.to_string())),
+            ..Default::default()
+        };
+        Entity::insert(event)
+            .exec(client.connection_ref())
+            .await
+            .unwrap();
+        let event = ActiveModel {
+            s3_object_id: Set(UuidGenerator::generate()),
+            event_type: Set(sea_orm_active_enums::EventType::Created),
+            key: Set("key".to_string()),
+            bucket: Set("bucket".to_string()),
+            sequencer: NotSet,
+            storage_class: Set(Some(sea_orm_active_enums::StorageClass::IntelligentTiering)),
+            ingest_id: Set(Some(Uuid::default())),
+            archive_status: Set(Some(ArchiveStatus::DeepArchiveAccess)),
+            e_tag: Set(Some(EXPECTED_QUOTED_E_TAG.to_string())),
+            last_modified_date: Set(Some("1970-01-01 00:00:00.000000 +00:00".parse().unwrap())),
             version_id: Set(default_version_id()),
             size: Set(Some(1)),
             is_current_state: Set(true),

--- a/app/filemanager/src/events/aws/crawl.rs
+++ b/app/filemanager/src/events/aws/crawl.rs
@@ -571,11 +571,18 @@ pub(crate) mod tests {
 
         let results = fetch_results(&client).await;
         assert_eq!(results.len(), 3);
-        assert_eq_crawl_event(results[0].clone(), event);
-        assert_eq!(results[1], event.clone().with_key("key1".to_string()));
-        assert_eq!(
-            results[2],
-            event.with_sequencer(None).with_is_current_state(false)
+        assert_eq_crawl_event(results[0].clone(), event.clone().with_reason(Reason::Crawl));
+        assert_eq_crawl_event(
+            results[1].clone(),
+            event
+                .clone()
+                .with_key("key1".to_string())
+                .with_size(Some(2))
+                .with_reason(Reason::Crawl),
+        );
+        assert_eq_crawl_event(
+            results[2].clone(),
+            event.with_sequencer(None).with_is_current_state(false),
         );
     }
 

--- a/app/filemanager/src/events/aws/crawl.rs
+++ b/app/filemanager/src/events/aws/crawl.rs
@@ -5,34 +5,26 @@ use crate::clients::aws::s3::Client;
 use crate::database::entities::sea_orm_active_enums::Reason;
 use crate::error::Result;
 use crate::events::aws::message::{EventType, default_version_id, quote_e_tag};
-use std::collections::HashSet;
-
-use crate::database::entities::s3_object;
-use crate::events::aws::{DiffMessages, FlatS3EventMessage, FlatS3EventMessages};
+use crate::events::aws::{FlatS3EventMessage, FlatS3EventMessages};
 use crate::uuid::UuidGenerator;
 use aws_sdk_s3::types::ObjectVersion;
 use chrono::Utc;
-use itertools::Itertools;
 
 /// Represents crawl operations.
 #[derive(Debug)]
 pub struct Crawl {
     client: Client,
-    database_state: Vec<s3_object::Model>,
 }
 
 impl Crawl {
     /// Create a new crawl.
-    pub fn new(client: Client, database_state: Vec<s3_object::Model>) -> Self {
-        Self {
-            client,
-            database_state,
-        }
+    pub fn new(client: Client) -> Self {
+        Self { client }
     }
 
     /// Create a new crawl with a default s3 client.
-    pub async fn with_defaults(database_state: Vec<s3_object::Model>) -> Self {
-        Self::new(Client::with_defaults().await, database_state)
+    pub async fn with_defaults() -> Self {
+        Self::new(Client::with_defaults().await)
     }
 
     /// Crawl S3 and produce the event messages that should be ingested.
@@ -45,34 +37,13 @@ impl Crawl {
         let versions = list.versions.unwrap_or_default();
 
         // We only want to crawl current objects.
-        let messages = versions
+        let messages: Vec<FlatS3EventMessage> = versions
             .into_iter()
             .filter(|object| object.is_latest.is_some_and(|latest| latest))
             .map(|object| FlatS3EventMessage::from(object).with_bucket(bucket.to_string()))
             .collect();
-        let mut database_state: Vec<FlatS3EventMessage> = self
-            .database_state
-            .into_iter()
-            .map(FlatS3EventMessage::from)
-            .collect();
 
-        // Take the difference between what is on S3, and the current database state. All records
-        // that are not on S3, but are in the database represent records that should be deleted from
-        // the database.
-        database_state
-            .iter_mut()
-            .for_each(|record| record.event_type = EventType::Deleted);
-
-        // The symmetric difference keeps the records that need to be deleted from the database.
-        let s3_state: HashSet<DiffMessages> =
-            HashSet::from_iter(Vec::<DiffMessages>::from(FlatS3EventMessages(messages)));
-        let database_state: HashSet<DiffMessages> = HashSet::from_iter(Vec::<DiffMessages>::from(
-            FlatS3EventMessages(database_state),
-        ));
-        let diff = s3_state.symmetric_difference(&database_state);
-
-        // Crawl the objects that are required by the diff.
-        Ok(FlatS3EventMessages::from(diff.cloned().collect_vec()))
+        Ok(FlatS3EventMessages(messages))
     }
 }
 
@@ -160,8 +131,10 @@ pub(crate) mod tests {
         let config = Config::default();
         let mut collecter = test_collecter(&config, &client).await;
         collecter.set_client(crawl_expectations());
+        collecter.set_crawl_bucket("bucket".to_string());
+        collecter.set_crawl_prefix("prefix".to_string());
 
-        let result = Crawl::new(collecter.client().clone(), vec![])
+        let result = Crawl::new(collecter.client().clone())
             .crawl_s3("bucket", Some("prefix".to_string()))
             .await
             .unwrap()

--- a/app/filemanager/src/events/aws/inventory.rs
+++ b/app/filemanager/src/events/aws/inventory.rs
@@ -533,16 +533,12 @@ impl From<Record> for FlatS3EventMessage {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::collections::HashSet;
-
-    use crate::events::aws::DiffMessages;
     use crate::events::aws::collecter::tests::mock_s3;
     use crate::events::aws::inventory::Manifest;
     use crate::events::aws::tests::EXPECTED_E_TAG;
     use aws_sdk_s3::operation::get_object::GetObjectOutput;
     use aws_sdk_s3::primitives::ByteStream;
     use aws_smithy_mocks::{Rule, mock};
-    use chrono::Days;
     use flate2::read::GzEncoder;
     use serde_json::Value;
     use serde_json::json;
@@ -564,60 +560,6 @@ pub(crate) mod tests {
     pub(crate) const EXPECTED_LAST_MODIFIED_ONE: &str = "2024-04-22T01:11:06.000Z";
     pub(crate) const EXPECTED_LAST_MODIFIED_TWO: &str = "2024-04-22T01:13:28.000Z";
     pub(crate) const EXPECTED_LAST_MODIFIED_THREE: &str = "2024-04-22T01:14:53.000Z";
-
-    #[test]
-    fn diff_messages() {
-        let database_records = vec![
-            FlatS3EventMessage {
-                bucket: "bucket".to_string(),
-                key: "key".to_string(),
-                version_id: "version".to_string(),
-                // Other fields shouldn't affect this.
-                last_modified_date: Some(DateTime::default()),
-                ..Default::default()
-            },
-            FlatS3EventMessage {
-                bucket: "bucket".to_string(),
-                key: "key1".to_string(),
-                version_id: "version".to_string(),
-                ..Default::default()
-            },
-        ];
-        let inventory_records = vec![
-            FlatS3EventMessage {
-                bucket: "bucket".to_string(),
-                key: "key".to_string(),
-                version_id: "version".to_string(),
-                last_modified_date: Some(
-                    DateTime::default().checked_add_days(Days::new(1)).unwrap(),
-                ),
-                ..Default::default()
-            },
-            FlatS3EventMessage {
-                bucket: "bucket".to_string(),
-                key: "key2".to_string(),
-                version_id: "version".to_string(),
-                ..Default::default()
-            },
-        ];
-
-        let inventory_records: HashSet<DiffMessages> = HashSet::from_iter(
-            Vec::<DiffMessages>::from(FlatS3EventMessages(inventory_records)),
-        );
-        let database_records: HashSet<DiffMessages> = HashSet::from_iter(
-            Vec::<DiffMessages>::from(FlatS3EventMessages(database_records)),
-        );
-
-        let diff = &inventory_records - &database_records;
-        let expected = HashSet::from_iter(vec![DiffMessages(FlatS3EventMessage {
-            bucket: "bucket".to_string(),
-            key: "key2".to_string(),
-            version_id: "version".to_string(),
-            ..Default::default()
-        })]);
-
-        assert_eq!(diff, expected);
-    }
 
     #[tokio::test]
     async fn parse_csv_manifest_from_checksum() {

--- a/app/filemanager/src/events/aws/mod.rs
+++ b/app/filemanager/src/events/aws/mod.rs
@@ -807,48 +807,14 @@ impl Hash for DiffMessages {
         self.0.bucket.hash(state);
         self.0.key.hash(state);
         self.0.version_id.hash(state);
-        self.0.size.hash(state);
-        self.0.e_tag.hash(state);
-        self.0.sha256.hash(state);
-        self.0.storage_class.hash(state);
-        self.0.last_modified_date.hash(state);
-        self.0.event_type.hash(state);
-        self.0.is_delete_marker.hash(state);
-        self.0.reason.hash(state);
-        self.0.archive_status.hash(state);
-        self.0.ingest_id.hash(state);
-        self.0.is_current_state.hash(state);
-        self.0.attributes.hash(state);
     }
 }
 
 impl PartialEq for DiffMessages {
     fn eq(&self, other: &Self) -> bool {
-        // Only values that are updatable should be considered equal for crawl
-        // purposes.
         self.0.bucket == other.0.bucket
             && self.0.key == other.0.key
             && self.0.version_id == other.0.version_id
-            && self.0.size == other.0.size
-            && self.0.e_tag == other.0.e_tag
-            && self.0.sha256 == other.0.sha256
-            && self.0.storage_class == other.0.storage_class
-            && self.0.last_modified_date == other.0.last_modified_date
-            && self.0.event_type == other.0.event_type
-            && self.0.is_delete_marker == other.0.is_delete_marker
-            && self.0.reason == other.0.reason
-            && self.0.archive_status == other.0.archive_status
-            && self.0.ingest_id == other.0.ingest_id
-            && self.0.is_current_state == other.0.is_current_state
-            && self.0.attributes == other.0.attributes
-
-        // Other values cannot be updated for crawls, or are always the same value, so they
-        // do not need to be considered.
-        // pub s3_object_id: Uuid,
-        // pub sequencer: Option<String>,
-        // pub event_time: Option<DateTime<Utc>>,
-        // pub number_duplicate_events: i64,
-        // pub number_reordered: i64,
     }
 }
 

--- a/app/filemanager/src/events/aws/mod.rs
+++ b/app/filemanager/src/events/aws/mod.rs
@@ -798,7 +798,7 @@ impl From<Vec<FlatS3EventMessages>> for FlatS3EventMessages {
 }
 
 /// A wrapper around event messages to allow for calculating a diff compared to the database
-/// state. Used to calculate the different between the database state and an incoming crawl to
+/// state. Used to calculate the difference between the database state and an incoming crawl to
 /// determine which new `Created` records should be ingested into the database.
 ///
 /// Checks for equality using the bucket, key and version_id. This is used to determine
@@ -877,7 +877,7 @@ impl From<DiffCrawlCreatedMessage> for DiffCrawlDeletedMessage {
 }
 
 /// A wrapper around event messages to allow for calculating a diff compared to the database
-/// state. Used to calculate the different between the database state and an incoming crawl to
+/// state. Used to calculate the difference between the database state and an incoming crawl to
 /// determine which new `Deleted` records should be ingested into the database.
 ///
 /// Checks for equality using the bucket, key and version_id. This is the only information needed

--- a/app/filemanager/src/events/mod.rs
+++ b/app/filemanager/src/events/mod.rs
@@ -1,10 +1,9 @@
 //! This module converts storage events into database objects.
 //!
 
-use async_trait::async_trait;
-
 use crate::error::Result;
 use crate::events::aws::{Events, TransposedS3EventMessages};
+use async_trait::async_trait;
 
 pub mod aws;
 

--- a/app/filemanager/src/handlers/aws.rs
+++ b/app/filemanager/src/handlers/aws.rs
@@ -19,7 +19,7 @@ use crate::error::Result;
 use crate::events::aws::collecter::CollecterBuilder;
 use crate::events::aws::inventory::{Inventory, Manifest};
 use crate::events::aws::message::EventType;
-use crate::events::aws::{DiffMessages, FlatS3EventMessages, TransposedS3EventMessages};
+use crate::events::aws::{DiffCrawlCreatedMessage, FlatS3EventMessages, TransposedS3EventMessages};
 use crate::events::{Collect, EventSourceType};
 
 /// Handle SQS events by manually calling the SQS receive function. This is meant
@@ -133,11 +133,12 @@ pub async fn ingest_s3_inventory(
 
     // Some back and forth between transposed vs not transposed events. Potential optimization
     // could involve using ndarray + slicing, with an enum representing the fields of the struct.
-    let transposed_events: HashSet<DiffMessages> = HashSet::from_iter(Vec::<DiffMessages>::from(
-        FlatS3EventMessages::from(transposed_events),
-    ));
-    let database_records: HashSet<DiffMessages> =
-        HashSet::from_iter(Vec::<DiffMessages>::from(database_records));
+    let transposed_events: HashSet<DiffCrawlCreatedMessage> =
+        HashSet::from_iter(Vec::<DiffCrawlCreatedMessage>::from(
+            FlatS3EventMessages::from(transposed_events),
+        ));
+    let database_records: HashSet<DiffCrawlCreatedMessage> =
+        HashSet::from_iter(Vec::<DiffCrawlCreatedMessage>::from(database_records));
 
     // The difference keeps the records that need to be crawled
     let diff_created = transposed_events

--- a/app/filemanager/src/handlers/aws.rs
+++ b/app/filemanager/src/handlers/aws.rs
@@ -19,7 +19,6 @@ use crate::error::Result;
 use crate::events::aws::collecter::CollecterBuilder;
 use crate::events::aws::inventory::{Inventory, Manifest};
 use crate::events::aws::message::EventType;
-use crate::events::aws::message::EventType::Created;
 use crate::events::aws::{DiffMessages, FlatS3EventMessages, TransposedS3EventMessages};
 use crate::events::{Collect, EventSourceType};
 
@@ -141,7 +140,6 @@ pub async fn ingest_s3_inventory(
                 record.event_type = EventType::Deleted;
                 record
             })
-            .filter(|record| record.event_type == Created)
             .collect(),
     );
 
@@ -231,6 +229,7 @@ pub(crate) mod tests {
         EXPECTED_LAST_MODIFIED_ONE, EXPECTED_LAST_MODIFIED_THREE, EXPECTED_LAST_MODIFIED_TWO,
         EXPECTED_QUOTED_E_TAG_KEY_2, MANIFEST_BUCKET, csv_manifest_from_key_expectations,
     };
+    use crate::events::aws::message::EventType::Created;
     use crate::events::aws::message::EventType::Deleted;
     use crate::events::aws::message::default_version_id;
     use crate::events::aws::tests::{

--- a/app/filemanager/src/routes/crawl.rs
+++ b/app/filemanager/src/routes/crawl.rs
@@ -193,7 +193,7 @@ pub async fn crawl_sync_s3(
     // Update events.
     let events = CollecterBuilder::default()
         .with_crawl_bucket(crawl.bucket)
-        .with_crawl_prefix(crawl.prefix.unwrap_or_default())
+        .with_crawl_prefix(crawl.prefix)
         .with_s3_client(state.s3_client().clone())
         .build(crawl_result, state.config(), state.database_client())
         .await
@@ -389,7 +389,7 @@ pub(crate) mod tests {
             state.clone(),
             "/s3/crawl/sync",
             Method::POST,
-            Body::from(json!({"bucket": "bucket", "prefix": "prefix"}).to_string()),
+            Body::from(json!({"bucket": "bucket"}).to_string()),
         )
         .await
         .1;
@@ -480,7 +480,7 @@ pub(crate) mod tests {
             get_tagging_expectation(
                 "key".to_string(),
                 default_version_id().to_string(),
-                expected_get_object_tagging(),
+                expected_get_object_tagging(Some(Uuid::default())),
             ),
             head_expectation(
                 "key1".to_string(),
@@ -495,7 +495,7 @@ pub(crate) mod tests {
             get_tagging_expectation(
                 "key1".to_string(),
                 default_version_id().to_string(),
-                expected_get_object_tagging(),
+                expected_get_object_tagging(Some(Uuid::default())),
             ),
         ])
     }

--- a/app/filemanager/src/routes/crawl.rs
+++ b/app/filemanager/src/routes/crawl.rs
@@ -415,10 +415,6 @@ pub(crate) mod tests {
         let (status, _) = crawl(&state).await;
 
         assert_eq!(status, StatusCode::NO_CONTENT);
-        // let result = state.into_crawl_result().await.unwrap();
-        //
-        // assert_eq!(result.status, Completed);
-        // assert_eq!(result.n_objects, Some(2));
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -484,14 +480,35 @@ pub(crate) mod tests {
         .await
     }
 
-    fn crawl_expectations() -> Client {
+    pub(crate) fn crawl_expectations() -> Client {
         list_object_expectations(&[
-            head_expectation(default_version_id().to_string(), expected_head_object()),
+            head_expectation(
+                "key".to_string(),
+                default_version_id().to_string(),
+                expected_head_object(),
+            ),
             put_tagging_expectation(
+                "key".to_string(),
                 default_version_id().to_string(),
                 expected_put_object_tagging(),
             ),
             get_tagging_expectation(
+                "key".to_string(),
+                default_version_id().to_string(),
+                expected_get_object_tagging(),
+            ),
+            head_expectation(
+                "key1".to_string(),
+                default_version_id().to_string(),
+                expected_head_object(),
+            ),
+            put_tagging_expectation(
+                "key1".to_string(),
+                default_version_id().to_string(),
+                expected_put_object_tagging(),
+            ),
+            get_tagging_expectation(
+                "key1".to_string(),
                 default_version_id().to_string(),
                 expected_get_object_tagging(),
             ),

--- a/app/filemanager/src/routes/crawl.rs
+++ b/app/filemanager/src/routes/crawl.rs
@@ -460,7 +460,7 @@ pub(crate) mod tests {
             state.clone(),
             "/s3/crawl",
             Method::POST,
-            Body::from(json!({"bucket": "bucket", "prefix": "prefix"}).to_string()),
+            Body::from(json!({"bucket": "bucket"}).to_string()),
         )
         .await
     }

--- a/app/filemanager/src/routes/crawl.rs
+++ b/app/filemanager/src/routes/crawl.rs
@@ -224,6 +224,8 @@ pub async fn crawl_sync_s3(
         .one(&conn)
         .await?
         .ok_or_else(|| CrawlError("expected crawl entry".to_string()))?;
+    conn.commit().await?;
+
     Ok(extract::Json(entry))
 }
 

--- a/app/filemanager/src/routes/filter/wildcard.rs
+++ b/app/filemanager/src/routes/filter/wildcard.rs
@@ -39,8 +39,8 @@ impl<T> WildcardEither<T> {
     }
 }
 
-/// A wildcard type represents a filter to match arbitrary characters. Use '%' for multiple characters
-/// and '_' for a single character. Use '\\' to escape these characters. Wildcards are converted to
+/// A wildcard type represents a filter to match arbitrary characters. Use '*' for multiple characters
+/// and '?' for a single character. Use '\\' to escape these characters. Wildcards are converted to
 /// postgres `like` or `ilike` queries.
 #[derive(Serialize, Deserialize, Debug, Default, ToSchema, Eq, PartialEq, Clone)]
 #[serde(default, rename_all = "camelCase")]


### PR DESCRIPTION
Closes #72

### Context

Previously the crawl operation was only able to add new `Created` events, but it was unable to add `Deleted` events to indicate that a record has been deleted from the database. This pull request introduces changes that allows the filemanager crawl to pick up when an object has been deleted.

### Motivation

I think this is an important fix to the crawl which allows it to maintain consistency across the filemanager database in case anything ever goes out of sync. With this change, a crawl should always reflect accurately what's on S3.

I don't think this will have any impact the way crawls work currently, as there shouldn't be many cases where a `Deleted` event needs to be created.

#### Changes include

* The crawl detects if there is a mismatch between the database state and S3, i.e whether any records should have `Deleted` events.
    * If there are any differences, new `Deleted` events are created like the existing crawl `Created` events.
    * This difference is implemented as a `HashSet` difference between the database state and S3 state to find which new records need to be created.
* The crawl also now detects whether a new record needs to be added at all.
   * Previously new records were always added when a crawl was initiated. Now, if there is no need to actually create a new record (e.g. none of the fields inside the database for the `key`, `bucket` and `version_id` would meaningfully change), then no record will be created.
   * This is an efficiency improvement, but some fields are ignored, such as the `reason` field which indicates that a crawl has happened. This means that if no other fields need to be updated, records might not show the reason to be "Crawl", even though a crawl has occurred.