### PR TITLE
fix: versioned current state

### DIFF
--- a/app/database/queries/api/reset_current_state.sql
+++ b/app/database/queries/api/reset_current_state.sql
@@ -1,4 +1,4 @@
--- Resets the `is_current_state` to false for a set of objects based on the `bucket` amd `key`. The current state of
+-- Resets the `is_current_state` to false for a set of objects based on the `bucket` and `key`. The current state of
 -- an object is the one that represents what S3 sees when fetching a key. I.e. it's the most current version of an
 -- object that hasn't been permanently deleted, and is not a delete marker.
 
@@ -36,7 +36,7 @@ current_versions as (
 ),
 -- This selects the single event that is the current state for the key, i.e. the record that represents the current
 -- version of all versioned objects. To do this, the query partitions over current versions of objects from the previous
--- query and selects the latest. Delete markers are treated specially because they should always non-current state.
+-- query and selects the latest. Delete markers are treated specially because they should always be non-current state.
 current_state as (
     select
         s3_object_id,

--- a/app/database/queries/api/reset_current_state.sql
+++ b/app/database/queries/api/reset_current_state.sql
@@ -1,6 +1,6 @@
--- Resets the `is_current_state` to false for a set of objects based on the `bucket`, `key`, `version_id`
--- and `sequencer`. This is used to update the current state so that a new object can have it's `is_current_state`
--- set to true based on whether it is a `Created` or `Deleted` event.
+-- Resets the `is_current_state` to false for a set of objects based on the `bucket` amd `key`. The current state of
+-- an object is the one that represents what S3 sees when fetching a key. I.e. it's the most current version of an
+-- object that hasn't been permanently deleted, and is not a delete marker.
 
 -- Unnest input.
 with input as (
@@ -8,53 +8,53 @@ with input as (
         *
     from unnest(
         $1::text[],
-        $2::text[],
-        $3::text[],
-        $4::text[]
+        $2::text[]
     ) as input (
         bucket,
-        key,
-        version_id,
-        sequencer
+        key
     )
 ),
--- Select objects to update.
-to_update as (
+-- This selects all valid current versions of an object, i.e. those that have not been permanently deleted from S3. To
+-- do this, the query will partition over version_ids and mark the object version as current if a `Created` event is
+-- the latest. Delete markers are treated specially in that they represent a current object version although one that
+-- has been deleted.
+current_versions as (
     select * from input cross join lateral (
         select
             s3_object_id,
-            -- This finds the first value in the set which represents the most up-to-date state.
-            -- If ordered by the sequencer, the first row is the one that needs to have `is_current_state`
-            -- set to 'true' only for `Created` events, as `Deleted` events are always non-current state.
-            case when row_number() over (order by s3_object.sequencer desc nulls last) = 1 then
-                event_type = 'Created'
-            -- Set `is_current_state` to 'false' for all other rows, as this is now historical data.
-            else
-                false
-            end as updated_state
+            is_delete_marker,
+            sequencer,
+            (
+                row_number() over (partition by s3_object.version_id order by s3_object.sequencer desc nulls last) = 1 and
+                (s3_object.is_delete_marker or s3_object.event_type = 'Created')
+            ) as is_current_version
         from s3_object
         where
-            -- This should be fairly efficient as it's only targeting objects where `is_current_state` is true,
-            -- or objects with the highest sequencer values (in case of an out-of-order event). This means that
-            -- although there is a performance impact for running this on ingestion, it should be minimal with
-            -- the right indexes.
             input.bucket = s3_object.bucket and
-            input.key = s3_object.key and
-            -- Note that we need to fetch all versions of an object, because when a record is updated,
-            -- previous versions need to have their `is_current_state` set to false.
-            -- This is an optimization which prevents querying against all objects in the set.
-            (
-                -- Only need to update current objects
-                s3_object.is_current_state = true or
-                -- Or objects where there is a newer sequencer than the one being processed.
-                -- This is required in case an out-of-order event is encountered. This always
-                -- includes the object being processed as it's required for the above row-logic.
-                s3_object.sequencer >= input.sequencer
-            )
+            input.key = s3_object.key
     ) s3_object
+),
+-- This selects the single event that is the current state for the key, i.e. the record that represents the current
+-- version of all versioned objects. To do this, the query partitions over current versions of objects from the previous
+-- query and selects the latest. Delete markers are treated specially because they should always non-current state.
+current_state as (
+    select
+        s3_object_id,
+        (
+            row_number() over (
+                partition by
+                    current_versions.bucket,
+                    current_versions.key,
+                    current_versions.is_current_version
+                order by current_versions.sequencer desc nulls last
+            ) = 1 and
+            current_versions.is_current_version and
+            not current_versions.is_delete_marker
+        ) as is_current_state
+    from current_versions
 )
 update s3_object
-set is_current_state = updated_state
-from to_update
-where s3_object.s3_object_id = to_update.s3_object_id
+set is_current_state = current_state.is_current_state
+from current_state
+where s3_object.s3_object_id = current_state.s3_object_id
 returning s3_object.s3_object_id, s3_object.is_current_state;

--- a/app/filemanager/src/database/aws/query.rs
+++ b/app/filemanager/src/database/aws/query.rs
@@ -64,8 +64,9 @@ impl Query {
         keys: Vec<String>,
     ) -> Result<()> {
         // Remove duplicate combinations of (bucket, key) as it's unnecessary to call multiple times.
-        let keys: HashSet<_> = HashSet::from_iter(buckets.into_iter().zip(keys.into_iter()));
-        let (buckets, keys): (Vec<_>, Vec<_>) = keys.into_iter().unzip();
+        let bucket_key_pairs: HashSet<_> =
+            HashSet::from_iter(buckets.into_iter().zip(keys.into_iter()));
+        let (buckets, keys): (Vec<_>, Vec<_>) = bucket_key_pairs.into_iter().unzip();
 
         let conn = conn.acquire().await?;
 

--- a/app/filemanager/src/database/aws/query.rs
+++ b/app/filemanager/src/database/aws/query.rs
@@ -1,4 +1,5 @@
 use sqlx::{Acquire, PgConnection, Postgres, Transaction, query, query_as};
+use std::collections::HashSet;
 
 use crate::database::Client;
 use crate::error::Result;
@@ -59,11 +60,13 @@ impl Query {
     pub async fn reset_current_state(
         &self,
         conn: &mut PgConnection,
-        buckets: &[String],
-        keys: &[String],
-        version_ids: &[String],
-        sequencers: &[Option<String>],
+        buckets: Vec<String>,
+        keys: Vec<String>,
     ) -> Result<()> {
+        // Remove duplicate combinations of (bucket, key) as it's unnecessary to call multiple times.
+        let keys: HashSet<_> = HashSet::from_iter(buckets.into_iter().zip(keys.into_iter()));
+        let (buckets, keys): (Vec<_>, Vec<_>) = keys.into_iter().unzip();
+
         let conn = conn.acquire().await?;
 
         query(include_str!(
@@ -71,8 +74,6 @@ impl Query {
         ))
         .bind(buckets)
         .bind(keys)
-        .bind(version_ids)
-        .bind(sequencers)
         .execute(&mut *conn)
         .await?;
 
@@ -87,19 +88,23 @@ impl Query {
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Add;
+    use super::*;
 
+    use crate::database::Ingest;
     use crate::database::aws::ingester::Ingester;
     use crate::database::aws::ingester::tests::test_events;
     use crate::database::aws::migration::tests::MIGRATOR;
+    use crate::events::EventSourceType;
+    use crate::events::aws::TransposedS3EventMessages;
+    use crate::events::aws::crawl::tests::{assert_eq_event, fetch_results};
+    use crate::events::aws::message::EventType;
     use crate::events::aws::message::EventType::Created;
     use crate::events::aws::tests::{
         EXPECTED_NEW_SEQUENCER_ONE, EXPECTED_SEQUENCER_CREATED_ONE, EXPECTED_VERSION_ID,
     };
     use chrono::{DateTime, Duration, Utc};
-    use sqlx::PgPool;
-
-    use super::*;
+    use sqlx::{Executor, PgPool};
+    use std::ops::Add;
 
     async fn ingest_test_records(pool: PgPool) -> (String, Option<DateTime<Utc>>) {
         let events = test_events(Some(Created));
@@ -178,23 +183,12 @@ mod tests {
             .0
     }
 
-    async fn query_reset_current_state(
-        new_key: &String,
-        query: &Query,
-        sequencer: &str,
-        conn: &mut PgConnection,
-    ) {
+    async fn query_reset_current_state(new_key: &String, query: &Query, conn: &mut PgConnection) {
         query
             .reset_current_state(
                 conn,
-                vec!["bucket".to_string(), "bucket".to_string()].as_slice(),
-                vec!["key".to_string(), new_key.to_string()].as_slice(),
-                vec![
-                    EXPECTED_VERSION_ID.to_string(),
-                    EXPECTED_VERSION_ID.to_string(),
-                ]
-                .as_slice(),
-                vec![Some(sequencer.to_string()), Some(sequencer.to_string())].as_slice(),
+                vec!["bucket".to_string(), "bucket".to_string()],
+                vec!["key".to_string(), new_key.to_string()],
             )
             .await
             .unwrap();
@@ -255,7 +249,7 @@ mod tests {
         let query = Query::new(client);
 
         let mut tx = query.client.pool().begin().await.unwrap();
-        query_reset_current_state(&new_key, &query, EXPECTED_NEW_SEQUENCER_ONE, &mut tx).await;
+        query_reset_current_state(&new_key, &query, &mut tx).await;
 
         let results = query_current_state(&new_key, &query, &mut tx).await;
 
@@ -268,5 +262,208 @@ mod tests {
                 assert!(result.is_current_state);
             }
         }
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn test_reset_current_state_version_id(pool: PgPool) {
+        let client = Client::from_pool(pool);
+
+        let event_one = FlatS3EventMessage::new_with_generated_id()
+            .with_key("key".to_string())
+            .with_bucket("bucket".to_string())
+            .with_version_id("1".to_string())
+            .with_sequencer(Some("1".to_string()))
+            .with_event_type(EventType::Created);
+
+        let mut events = vec![event_one.clone()];
+        let result = ingest_events(&client, events.clone()).await;
+        assert_eq!(result.len(), 1);
+        assert_eq_event(
+            result[0].clone(),
+            event_one.clone().with_is_current_state(true),
+        );
+
+        let event_two = event_one
+            .clone()
+            .regenerate_ids()
+            .with_version_id("2".to_string())
+            .with_sequencer(Some("2".to_string()));
+        events.push(event_two.clone());
+        let result = ingest_events(&client, events.clone()).await;
+        assert_eq!(result.len(), 2);
+        assert_eq_event(result[0].clone(), event_one.clone());
+        assert_eq_event(
+            result[1].clone(),
+            event_two.clone().with_is_current_state(true),
+        );
+
+        let event_three = event_one
+            .clone()
+            .regenerate_ids()
+            .with_version_id("3".to_string())
+            .with_sequencer(Some("3".to_string()));
+        events.push(event_three.clone());
+        let result = ingest_events(&client, events.clone()).await;
+        assert_eq!(result.len(), 3);
+        assert_eq_event(result[0].clone(), event_one.clone());
+        assert_eq_event(result[1].clone(), event_two.clone());
+        assert_eq_event(
+            result[2].clone(),
+            event_three.clone().with_is_current_state(true),
+        );
+
+        // Permanently delete non-current version.
+        let event_four = event_one
+            .clone()
+            .regenerate_ids()
+            .with_version_id("2".to_string())
+            .with_sequencer(Some("4".to_string()))
+            .with_event_type(EventType::Deleted);
+        events.push(event_four.clone());
+        let result = ingest_events(&client, events.clone()).await;
+        assert_eq!(result.len(), 4);
+        assert_eq_event(result[0].clone(), event_one.clone());
+        assert_eq_event(result[1].clone(), event_two.clone());
+        assert_eq_event(
+            result[2].clone(),
+            event_three.clone().with_is_current_state(true),
+        );
+        assert_eq_event(result[3].clone(), event_four.clone());
+
+        // Create delete marker.
+        let event_five = event_one
+            .clone()
+            .regenerate_ids()
+            .with_version_id("4".to_string())
+            .with_sequencer(Some("5".to_string()))
+            .with_event_type(EventType::Deleted)
+            .with_is_delete_marker(true);
+        events.push(event_five.clone());
+        let result = ingest_events(&client, events.clone()).await;
+        assert_eq!(result.len(), 5);
+        assert_eq_event(result[0].clone(), event_one.clone());
+        assert_eq_event(result[1].clone(), event_two.clone());
+        assert_eq_event(result[2].clone(), event_three.clone());
+        assert_eq_event(result[3].clone(), event_four.clone());
+        assert_eq_event(result[4].clone(), event_five.clone());
+
+        // Upload new object over delete marker.
+        let event_six = event_one
+            .clone()
+            .regenerate_ids()
+            .with_version_id("5".to_string())
+            .with_sequencer(Some("6".to_string()));
+        events.push(event_six.clone());
+        let result = ingest_events(&client, events.clone()).await;
+        assert_eq!(result.len(), 6);
+        assert_eq_event(result[0].clone(), event_one.clone());
+        assert_eq_event(result[1].clone(), event_two.clone());
+        assert_eq_event(result[2].clone(), event_three.clone());
+        assert_eq_event(result[3].clone(), event_four.clone());
+        assert_eq_event(result[4].clone(), event_five.clone());
+        assert_eq_event(
+            result[5].clone(),
+            event_six.clone().with_is_current_state(true),
+        );
+
+        // Permanently delete object version, delete marker is now current.
+        let event_seven = event_one
+            .clone()
+            .regenerate_ids()
+            .with_version_id("5".to_string())
+            .with_sequencer(Some("7".to_string()))
+            .with_event_type(EventType::Deleted);
+        events.push(event_seven.clone());
+        let result = ingest_events(&client, events.clone()).await;
+        assert_eq!(result.len(), 7);
+        assert_eq_event(result[0].clone(), event_one.clone());
+        assert_eq_event(result[1].clone(), event_two.clone());
+        assert_eq_event(result[2].clone(), event_three.clone());
+        assert_eq_event(result[3].clone(), event_four.clone());
+        assert_eq_event(result[4].clone(), event_five.clone());
+        assert_eq_event(result[5].clone(), event_six.clone());
+        assert_eq_event(result[6].clone(), event_seven.clone());
+
+        // Permanently delete delete marker, old version is now current.
+        let event_eight = event_one
+            .clone()
+            .regenerate_ids()
+            .with_version_id("4".to_string())
+            .with_sequencer(Some("8".to_string()))
+            .with_event_type(EventType::Deleted);
+        events.push(event_eight.clone());
+        let result = ingest_events(&client, events.clone()).await;
+        assert_eq!(result.len(), 8);
+        assert_eq_event(result[0].clone(), event_one.clone());
+        assert_eq_event(result[1].clone(), event_two.clone());
+        assert_eq_event(
+            result[2].clone(),
+            event_three.clone().with_is_current_state(true),
+        );
+        assert_eq_event(result[3].clone(), event_four.clone());
+        assert_eq_event(result[4].clone(), event_five.clone());
+        assert_eq_event(result[5].clone(), event_six.clone());
+        assert_eq_event(result[6].clone(), event_seven.clone());
+        assert_eq_event(result[7].clone(), event_eight.clone());
+
+        // Permanently delete object, first object now current.
+        let event_nine = event_one
+            .clone()
+            .regenerate_ids()
+            .with_version_id("3".to_string())
+            .with_sequencer(Some("9".to_string()))
+            .with_event_type(EventType::Deleted);
+        events.push(event_nine.clone());
+        let result = ingest_events(&client, events.clone()).await;
+        assert_eq!(result.len(), 9);
+        assert_eq_event(
+            result[0].clone(),
+            event_one.clone().with_is_current_state(true),
+        );
+        assert_eq_event(result[1].clone(), event_two.clone());
+        assert_eq_event(result[2].clone(), event_three.clone());
+        assert_eq_event(result[3].clone(), event_four.clone());
+        assert_eq_event(result[4].clone(), event_five.clone());
+        assert_eq_event(result[5].clone(), event_six.clone());
+        assert_eq_event(result[6].clone(), event_seven.clone());
+        assert_eq_event(result[7].clone(), event_eight.clone());
+        assert_eq_event(result[8].clone(), event_nine.clone());
+
+        // Permanently delete last object.
+        let event_ten = event_one
+            .clone()
+            .regenerate_ids()
+            .with_version_id("1".to_string())
+            .with_sequencer(Some("99".to_string()))
+            .with_event_type(EventType::Deleted);
+        events.push(event_ten.clone());
+        let result = ingest_events(&client, events.clone()).await;
+        assert_eq!(result.len(), 10);
+        assert_eq_event(result[0].clone(), event_one.clone());
+        assert_eq_event(result[1].clone(), event_two.clone());
+        assert_eq_event(result[2].clone(), event_three.clone());
+        assert_eq_event(result[3].clone(), event_four.clone());
+        assert_eq_event(result[4].clone(), event_five.clone());
+        assert_eq_event(result[5].clone(), event_six.clone());
+        assert_eq_event(result[6].clone(), event_seven.clone());
+        assert_eq_event(result[7].clone(), event_eight.clone());
+        assert_eq_event(result[8].clone(), event_nine.clone());
+        assert_eq_event(result[9].clone(), event_ten.clone());
+    }
+
+    async fn ingest_events(
+        client: &Client,
+        events: Vec<FlatS3EventMessage>,
+    ) -> Vec<FlatS3EventMessage> {
+        client
+            .ingest(EventSourceType::S3(TransposedS3EventMessages::from(
+                FlatS3EventMessages(events),
+            )))
+            .await
+            .unwrap();
+        let results = fetch_results(client).await;
+        client.pool().execute("truncate s3_object").await.unwrap();
+
+        results
     }
 }

--- a/app/filemanager/src/events/aws/crawl.rs
+++ b/app/filemanager/src/events/aws/crawl.rs
@@ -182,7 +182,7 @@ pub(crate) mod tests {
             .with_is_current_state(true)
             .with_sha256(Some(EXPECTED_SHA256.to_string()));
         assert_eq!(results.len(), 2);
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[0].clone(),
             event
                 .with_sequencer(Some(
@@ -190,7 +190,7 @@ pub(crate) mod tests {
                 ))
                 .with_reason(Reason::Crawl),
         );
-        assert_eq_crawl_event(results[1].clone(), expected_unaffected_record_two());
+        assert_eq_event(results[1].clone(), expected_unaffected_record_two());
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -212,8 +212,8 @@ pub(crate) mod tests {
             .with_sha256(Some(EXPECTED_SHA256.to_string()));
         let results = ingest_crawl(client.clone(), event.clone(), vec![default_version_id()]).await;
         assert_eq!(results.len(), 2);
-        assert_eq_crawl_event(results[0].clone(), event.clone());
-        assert_eq_crawl_event(results[1].clone(), expected_unaffected_record_two());
+        assert_eq_event(results[0].clone(), event.clone());
+        assert_eq_event(results[1].clone(), expected_unaffected_record_two());
 
         let event = FlatS3EventMessage::new_with_generated_id()
             .with_key("key".to_string())
@@ -231,8 +231,8 @@ pub(crate) mod tests {
             .with_reason(Reason::CreatedCopy);
         let results = ingest_crawl(client.clone(), event.clone(), vec![default_version_id()]).await;
         assert_eq!(results.len(), 2);
-        assert_eq_crawl_event(results[0].clone(), event);
-        assert_eq_crawl_event(results[1].clone(), expected_unaffected_record_two());
+        assert_eq_event(results[0].clone(), event);
+        assert_eq_event(results[1].clone(), expected_unaffected_record_two());
 
         let event = FlatS3EventMessage::new_with_generated_id()
             .with_key("key".to_string())
@@ -251,8 +251,8 @@ pub(crate) mod tests {
 
         let results = ingest_crawl(client.clone(), event.clone(), vec![default_version_id()]).await;
         assert_eq!(results.len(), 2);
-        assert_eq_crawl_event(results[0].clone(), event);
-        assert_eq_crawl_event(results[1].clone(), expected_unaffected_record_two());
+        assert_eq_event(results[0].clone(), event);
+        assert_eq_event(results[1].clone(), expected_unaffected_record_two());
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -275,7 +275,7 @@ pub(crate) mod tests {
         let results = ingest_crawl(client.clone(), event.clone(), vec![default_version_id()]).await;
         assert_eq!(results.len(), 3);
         assert_eq!(results[0], event.clone().with_is_current_state(false));
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[1].clone(),
             event
                 .with_sequencer(Some(
@@ -284,7 +284,7 @@ pub(crate) mod tests {
                 .with_reason(Reason::Crawl)
                 .with_storage_class(Some(StorageClass::IntelligentTiering)),
         );
-        assert_eq_crawl_event(results[2].clone(), expected_unaffected_record_two());
+        assert_eq_event(results[2].clone(), expected_unaffected_record_two());
 
         let event = FlatS3EventMessage::new_with_generated_id()
             .with_key("key".to_string())
@@ -302,7 +302,7 @@ pub(crate) mod tests {
         let results = ingest_crawl(client.clone(), event.clone(), vec![default_version_id()]).await;
         assert_eq!(results.len(), 3);
         assert_eq!(results[0], event.clone().with_is_current_state(false));
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[1].clone(),
             event
                 .with_sequencer(Some(
@@ -311,7 +311,7 @@ pub(crate) mod tests {
                 .with_reason(Reason::Crawl)
                 .with_ingest_id(Some(Uuid::default())),
         );
-        assert_eq_crawl_event(results[2].clone(), expected_unaffected_record_two());
+        assert_eq_event(results[2].clone(), expected_unaffected_record_two());
 
         let event = FlatS3EventMessage::new_with_generated_id()
             .with_key("key".to_string())
@@ -329,7 +329,7 @@ pub(crate) mod tests {
         let results = ingest_crawl(client.clone(), event.clone(), vec![default_version_id()]).await;
         assert_eq!(results.len(), 3);
         assert_eq!(results[0], event.clone().with_is_current_state(false));
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[1].clone(),
             event
                 .with_sequencer(Some(
@@ -338,7 +338,7 @@ pub(crate) mod tests {
                 .with_reason(Reason::Crawl)
                 .with_archive_status(Some(ArchiveStatus::DeepArchiveAccess)),
         );
-        assert_eq_crawl_event(results[2].clone(), expected_unaffected_record_two());
+        assert_eq_event(results[2].clone(), expected_unaffected_record_two());
 
         let event = FlatS3EventMessage::new_with_generated_id()
             .with_key("key".to_string())
@@ -356,7 +356,7 @@ pub(crate) mod tests {
         let results = ingest_crawl(client.clone(), event.clone(), vec![default_version_id()]).await;
         assert_eq!(results.len(), 3);
         assert_eq!(results[0], event.clone().with_is_current_state(false));
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[1].clone(),
             event
                 .with_sequencer(Some(
@@ -365,7 +365,7 @@ pub(crate) mod tests {
                 .with_reason(Reason::Crawl)
                 .with_e_tag(Some(EXPECTED_QUOTED_E_TAG.to_string())),
         );
-        assert_eq_crawl_event(results[2].clone(), expected_unaffected_record_two());
+        assert_eq_event(results[2].clone(), expected_unaffected_record_two());
 
         let event = FlatS3EventMessage::new_with_generated_id()
             .with_key("key".to_string())
@@ -383,7 +383,7 @@ pub(crate) mod tests {
         let results = ingest_crawl(client.clone(), event.clone(), vec![default_version_id()]).await;
         assert_eq!(results.len(), 3);
         assert_eq!(results[0], event.clone().with_is_current_state(false));
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[1].clone(),
             event
                 .with_sequencer(Some(
@@ -392,7 +392,7 @@ pub(crate) mod tests {
                 .with_last_modified_date(Some("1970-01-01 00:00:00.000000 +00:00".parse().unwrap()))
                 .with_reason(Reason::Crawl),
         );
-        assert_eq_crawl_event(results[2].clone(), expected_unaffected_record_two());
+        assert_eq_event(results[2].clone(), expected_unaffected_record_two());
 
         let event = FlatS3EventMessage::new_with_generated_id()
             .with_key("key".to_string())
@@ -410,7 +410,7 @@ pub(crate) mod tests {
         let results = ingest_crawl(client.clone(), event.clone(), vec![default_version_id()]).await;
         assert_eq!(results.len(), 3);
         assert_eq!(results[0], event.clone().with_is_current_state(false));
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[1].clone(),
             event
                 .with_sequencer(Some(
@@ -419,7 +419,7 @@ pub(crate) mod tests {
                 .with_size(Some(1))
                 .with_reason(Reason::Crawl),
         );
-        assert_eq_crawl_event(results[2].clone(), expected_unaffected_record_two());
+        assert_eq_event(results[2].clone(), expected_unaffected_record_two());
 
         let event = FlatS3EventMessage::new_with_generated_id()
             .with_key("key".to_string())
@@ -437,7 +437,7 @@ pub(crate) mod tests {
         let results = ingest_crawl(client.clone(), event.clone(), vec![default_version_id()]).await;
         assert_eq!(results.len(), 3);
         assert_eq!(results[0], event.clone().with_is_current_state(false));
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[1].clone(),
             event
                 .with_sequencer(Some(
@@ -446,7 +446,7 @@ pub(crate) mod tests {
                 .with_reason(Reason::Crawl)
                 .with_sha256(Some(EXPECTED_SHA256.to_string())),
         );
-        assert_eq_crawl_event(results[2].clone(), expected_unaffected_record_two());
+        assert_eq_event(results[2].clone(), expected_unaffected_record_two());
 
         // Attributes carry over from existing events in the database.
         let event = FlatS3EventMessage::new_with_generated_id()
@@ -466,7 +466,7 @@ pub(crate) mod tests {
         let results = ingest_crawl(client.clone(), event.clone(), vec![default_version_id()]).await;
         assert_eq!(results.len(), 2);
         assert_eq!(results[0], event.clone());
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[1].clone(),
             expected_unaffected_record_two()
                 .with_sequencer(Some(
@@ -498,8 +498,8 @@ pub(crate) mod tests {
         assert_eq!(results.len(), 4);
         assert_eq!(results[0], event.clone().with_is_current_state(false));
 
-        assert_eq_crawl_event(results[1].clone(), expected_unaffected_record_one());
-        assert_eq_crawl_event(results[2].clone(), expected_unaffected_record_two());
+        assert_eq_event(results[1].clone(), expected_unaffected_record_one());
+        assert_eq_event(results[2].clone(), expected_unaffected_record_two());
 
         let mut deleted = results[3].clone();
         assert!(deleted.event_time.is_some());
@@ -600,7 +600,7 @@ pub(crate) mod tests {
 
         let results = fetch_results(&client).await;
         assert_eq!(results.len(), 5);
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[0].clone(),
             event
                 .clone()
@@ -609,7 +609,7 @@ pub(crate) mod tests {
                 .with_event_type(EventType::Deleted)
                 .with_is_current_state(false),
         );
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[1].clone(),
             event
                 .clone()
@@ -620,7 +620,7 @@ pub(crate) mod tests {
                     "000000000000000000000000000000-0100000000000000".to_string(),
                 )),
         );
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[2].clone(),
             event
                 .clone()
@@ -629,14 +629,14 @@ pub(crate) mod tests {
                     "000000000000000000000000000000-0200000000000000".to_string(),
                 )),
         );
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[3].clone(),
             event
                 .clone()
                 .with_sequencer(None)
                 .with_is_current_state(false),
         );
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[4].clone(),
             event
                 .clone()
@@ -727,7 +727,7 @@ pub(crate) mod tests {
 
         let results = fetch_results(&client).await;
         assert_eq!(results.len(), 5);
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[0].clone(),
             event
                 .clone()
@@ -738,7 +738,7 @@ pub(crate) mod tests {
                     "000000000000000000000000000000-0100000000000000".to_string(),
                 )),
         );
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[1].clone(),
             event
                 .clone()
@@ -747,7 +747,7 @@ pub(crate) mod tests {
                 .with_event_type(EventType::Deleted)
                 .with_is_current_state(false),
         );
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[2].clone(),
             event
                 .clone()
@@ -756,14 +756,14 @@ pub(crate) mod tests {
                     "000000000000000000000000000000-0200000000000000".to_string(),
                 )),
         );
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[3].clone(),
             event
                 .clone()
                 .with_sequencer(None)
                 .with_is_current_state(false),
         );
-        assert_eq_crawl_event(
+        assert_eq_event(
             results[4].clone(),
             event
                 .clone()
@@ -773,7 +773,7 @@ pub(crate) mod tests {
         );
     }
 
-    fn assert_eq_crawl_event(mut left: FlatS3EventMessage, right: FlatS3EventMessage) {
+    pub(crate) fn assert_eq_event(mut left: FlatS3EventMessage, right: FlatS3EventMessage) {
         left.s3_object_id = right.s3_object_id;
         left.event_time = right.event_time;
         assert_eq!(left, right);
@@ -947,7 +947,7 @@ pub(crate) mod tests {
         results
     }
 
-    async fn fetch_results(client: &database::Client) -> Vec<FlatS3EventMessage> {
+    pub(crate) async fn fetch_results(client: &database::Client) -> Vec<FlatS3EventMessage> {
         S3Object::find()
             .order_by_asc(Column::Sequencer)
             .order_by_asc(Column::Key)

--- a/app/filemanager/src/routes/list.rs
+++ b/app/filemanager/src/routes/list.rs
@@ -784,7 +784,7 @@ pub(crate) mod tests {
         )
         .await;
         let mut expected_first = entries[0].clone();
-        expected_first.is_current_state = false;
+        expected_first.is_current_state = true;
         let mut expected_second = entries[1].clone();
         expected_second.is_current_state = false;
         assert_eq!(result.results(), vec![expected_first, expected_second]);


### PR DESCRIPTION
Closes #76 

This PR fixes an issue with versioned objects not tracking the `is_current_state` properly, where it was possible for the `is_current_state` to be false, even though it should have been true for a specific record. 

### Impact
This bug only impacted things if old object versions were permanently deleted. It wouldn't have appeared if objects were simply overwritten (without permanently deleting anything), or if all objects were permanently deleted in one go. 

### Changes
* Fixes the `reset_current_state` function to take into account old versioned objects when updating the current state.

### Explanation 
This logic is implemented as a two-part query, where first all possible versions of an object are identified, and then the most up-to-date version is selected out of those, in order to match what S3 sees.

E.g. consider an object with two versions, one of them is the current version, and another is the old version.

The first CTE - `current_versions` - determines all possible versions that are valid, which returns both objects as they are both valid versions: <img width="1607" height="125" alt="image" src="https://github.com/user-attachments/assets/26a87ed6-27ea-4e36-8cb9-94357f41858e" />
The `current` column represents records that would be seen on S3 if the `"Show versions"` is toggled on. 

The next CTE - `current_state` - picks the latest version according to the sequencer:
<img width="1607" height="125" alt="image" src="https://github.com/user-attachments/assets/f709d0cf-9e1b-4d7c-981b-121d6769b3e5" />
The `updated_state` column represents records that would be seen on S3 if the `"Show versions"` is toggled off, i.e. this is the real current state.

The reason this has to be done is two passes is because of the nested ranking, the `current_state` CTE depends on the order and output of `current_versions`. 

When a version is permanently deleted, the current state reverts back to an old version if available, matching what's seen on S3. The delete marker is also considered - if a delete marker is permanently deleted, then the object is reverts back to the most recent version. 