### PR TITLE
test: incorrect .env mv command

### DIFF
--- a/infrastructure/toolchain/stateless-stack.ts
+++ b/infrastructure/toolchain/stateless-stack.ts
@@ -58,7 +58,7 @@ export class StatelessStack extends cdk.Stack {
         },
       },
       unitAppTestConfig: {
-        command: ['cd app', 'make test', 'mv .env.example .env'],
+        command: ['cd app', 'mv .env.example .env', 'make test'],
       },
     });
 


### PR DESCRIPTION
Related to #79 

### Changes
* Move should occur before test.