### PR TITLE
refactor: performance engineering

### DIFF
--- a/app/database/migrations/0009_s3_remove_unused_indexes.sql
+++ b/app/database/migrations/0009_s3_remove_unused_indexes.sql
@@ -1,0 +1,13 @@
+-- Remove indexes on s3_object that are unused or redundant.
+
+-- Set the lock timeout just in case in order to not hold `access exclusive` for too long.
+set local lock_timeout = '10s';
+
+-- No scans in database as order by already sorts in memory.
+drop index if exists sequencer_index;
+-- Relatively unused, as reset_current_state only partitions rather than filtering.
+drop index if exists version_id_index;
+-- Relatively unused as a bool value isn't chosen often.
+drop index if exists is_current_state_index;
+-- Used, but not useful as the reset_current_state does a fallback to regular bucket, key, version_id constraints anyway.
+drop index if exists reset_current_state_index;

--- a/app/database/queries/api/reset_current_state.sql
+++ b/app/database/queries/api/reset_current_state.sql
@@ -62,4 +62,5 @@ update s3_object
 set is_current_state = current_state_ordered.is_current_state
 from current_state_ordered
 where s3_object.s3_object_id = current_state_ordered.s3_object_id
+    and s3_object.is_current_state is distinct from current_state_ordered.is_current_state
 returning s3_object.s3_object_id, s3_object.is_current_state;

--- a/app/filemanager/src/database/mod.rs
+++ b/app/filemanager/src/database/mod.rs
@@ -4,7 +4,7 @@
 use async_trait::async_trait;
 use sea_orm::{DatabaseConnection, SqlxPostgresConnector};
 use sqlx::PgPool;
-use sqlx::postgres::PgConnectOptions;
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use tracing::debug;
 
 use crate::database::aws::credentials::IamGenerator;
@@ -64,7 +64,12 @@ impl Client {
         generator: Option<impl CredentialGenerator>,
         config: &Config,
     ) -> Result<PgPool> {
-        Ok(PgPool::connect_with(Self::pg_connect_options(generator, config).await?).await?)
+        // Reduce connections per Lambda, there shouldn't be any need to more than 2 connections,
+        // as a batch is processed with an insert and resetting the current state.
+        Ok(PgPoolOptions::new()
+            .max_connections(2)
+            .connect_with(Self::pg_connect_options(generator, config).await?)
+            .await?)
     }
 
     /// Create database connect options using a series of credential loading logic.

--- a/infrastructure/stage/functions/ingest.ts
+++ b/infrastructure/stage/functions/ingest.ts
@@ -57,7 +57,14 @@ export class IngestFunction extends Function {
     this.addAwsManagedPolicy('service-role/AWSLambdaSQSQueueExecutionRole');
 
     props.ingestQueues.forEach((source) => {
-      const eventSource = new SqsEventSource(source);
+      // Reduce the ingestion speed to reduce ACU usage on the shared cluster. There's no
+      // need to have more than 10 Lambdas running concurrently, and the SQS should batch more
+      // aggresively.
+      const eventSource = new SqsEventSource(source, {
+        batchSize: 10000,
+        maxBatchingWindow: Duration.seconds(5),
+        maxConcurrency: 10,
+      });
       this.function.addEventSource(eventSource);
     });
     this.addPoliciesForBuckets(props.buckets, [

--- a/infrastructure/stage/functions/ingest.ts
+++ b/infrastructure/stage/functions/ingest.ts
@@ -62,7 +62,7 @@ export class IngestFunction extends Function {
       // aggresively.
       const eventSource = new SqsEventSource(source, {
         batchSize: 10000,
-        maxBatchingWindow: Duration.seconds(5),
+        maxBatchingWindow: Duration.seconds(30),
         maxConcurrency: 10,
       });
       this.function.addEventSource(eventSource);


### PR DESCRIPTION
### Changes
* Increase batch size and reduce maximum concurrency on the SQS queue to avoid increasing ACU too much.
* Only update current state for records that actually need changing.
* Removes some ununsed indexes:

Looking at [`idx_scan`](https://www.postgresql.org/docs/current/monitoring-stats.html) shows which indexes get used:
```
index                           |  scans   |  size   | enforces_constraint | is_pk
--------------------------------+----------+---------+---------------------+-------
 sequencer_index                |        0 | 2432 MB | f                   | f
 version_id_index               |       12 | 3428 MB | f                   | f
 is_current_state_index         |       12 | 530 MB  | f                   | f
 s3_object_current_state_unique |      106 | 1546 MB | t                   | f
 attributes_index               |     9696 | 122 MB  | f                   | f
 key_index                      |    12758 | 3103 MB | f                   | f
 reset_current_state_index      |    32566 | 16 GB   | f                   | f
 ingest_id_index                |   627550 | 1339 MB | f                   | f
 sequencer_unique               |  4777058 | 19 GB   | t                   | f
 deleted_sequencer_unique       |  4950219 | 14 GB   | t                   | f
 s3_object_pkey                 | 31908556 | 2019 MB | t                   | t
```

The first three are basically unused, so they can be dropped. `reset_current_state_index` is used, but it's redundant as the `reset_current_state` query will fall back to regular constraints anyway. For example, dropping the index shows that it would instead use `deleted_sequencer_unique`.

```
                                                                                     QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------
 Index Scan using deleted_sequencer_unique on s3_object  (cost=0.81..46.03 rows=13 width=73) (actual time=4.324..5.257 rows=2 loops=1)
   Index Cond: ((bucket = 'pipeline-prod-cache-503977275616-ap-southeast-2'::text) AND (key = '<example_key>'::text))
   Buffers: shared hit=3 read=7
   I/O Timings: shared read=5.067
 Planning:
   Buffers: shared hit=82
 Planning Time: 0.409 ms
 Execution Time: 5.297 ms
(8 rows)
```

This does end up being slightly slower (with this example), however I think the maintenance of a 16GB index would make removing it worthwhile, as the slow down isn't significant.
