### PR TITLE
fix: filemanager fd issue

### DIFF
--- a/app/filemanager/src/database/mod.rs
+++ b/app/filemanager/src/database/mod.rs
@@ -65,7 +65,7 @@ impl Client {
         config: &Config,
     ) -> Result<PgPool> {
         Ok(PgPoolOptions::new()
-            .max_connections(config.database_max_connections())
+            .max_connections(config.database_max_connections().get())
             .connect_with(Self::pg_connect_options(generator, config).await?)
             .await?)
     }

--- a/app/filemanager/src/database/mod.rs
+++ b/app/filemanager/src/database/mod.rs
@@ -64,10 +64,8 @@ impl Client {
         generator: Option<impl CredentialGenerator>,
         config: &Config,
     ) -> Result<PgPool> {
-        // Reduce connections per Lambda, there shouldn't be any need to more than 2 connections,
-        // as a batch is processed with an insert and resetting the current state.
         Ok(PgPoolOptions::new()
-            .max_connections(2)
+            .max_connections(config.database_max_connections())
             .connect_with(Self::pg_connect_options(generator, config).await?)
             .await?)
     }

--- a/app/filemanager/src/env.rs
+++ b/app/filemanager/src/env.rs
@@ -8,6 +8,7 @@ use envy::from_env;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer};
 use serde_with::serde_as;
+use std::num::{NonZeroU32, NonZeroUsize};
 use std::result;
 use std::str::FromStr;
 use url::Url;
@@ -54,19 +55,19 @@ pub struct Config {
     #[serde(rename = "filemanager_access_key_secret_id")]
     pub(crate) access_key_secret_id: Option<String>,
     #[serde(rename = "filemanager_crawl_concurrency")]
-    pub(crate) crawl_concurrency: usize,
+    pub(crate) crawl_concurrency: NonZeroUsize,
     #[serde(rename = "filemanager_database_max_connections")]
-    pub(crate) database_max_connections: u32,
+    pub(crate) database_max_connections: NonZeroU32,
 }
 
 /// Default presigned URL expiry time, 7 days.
 pub const DEFAULT_PRESIGN_EXPIRY: Duration = Duration::days(7);
 
 /// Default maximum number of objects processed concurrently.
-pub const DEFAULT_CRAWL_CONCURRENCY: usize = 50;
+pub const DEFAULT_CRAWL_CONCURRENCY: NonZeroUsize = NonZeroUsize::new(50).unwrap();
 
 /// Default maximum number of database connections per Lambda execution environment.
-pub const DEFAULT_DATABASE_MAX_CONNECTIONS: u32 = 2;
+pub const DEFAULT_DATABASE_MAX_CONNECTIONS: NonZeroU32 = NonZeroU32::new(2).unwrap();
 
 fn parse_limit<'de, D>(deserializer: D) -> result::Result<Option<u64>, D::Error>
 where
@@ -217,12 +218,12 @@ impl Config {
     }
 
     /// Get the maximum number of objects processed concurrently.
-    pub fn crawl_concurrency(&self) -> usize {
+    pub fn crawl_concurrency(&self) -> NonZeroUsize {
         self.crawl_concurrency
     }
 
     /// Get the maximum number of database connections per Lambda execution environment.
-    pub fn database_max_connections(&self) -> u32 {
+    pub fn database_max_connections(&self) -> NonZeroU32 {
         self.database_max_connections
     }
 
@@ -297,8 +298,8 @@ mod tests {
                 api_cors_allow_methods: vec!["GET".to_string(), "POST".to_string()],
                 api_cors_allow_headers: vec!["Authorization".to_string(), "Accept".to_string()],
                 access_key_secret_id: Some("id".to_string()),
-                crawl_concurrency: 100,
-                database_max_connections: 10,
+                crawl_concurrency: NonZeroUsize::new(100).unwrap(),
+                database_max_connections: NonZeroU32::new(10).unwrap(),
             }
         )
     }
@@ -308,5 +309,20 @@ mod tests {
         let config: Config = from_iter(vec![]).unwrap();
 
         assert_eq!(config, Default::default());
+    }
+
+    #[test]
+    fn test_environment_zero_is_rejected() {
+        let data = vec![("FILEMANAGER_CRAWL_CONCURRENCY", "0")]
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()));
+
+        assert!(from_iter::<_, Config>(data).is_err());
+
+        let data = vec![("FILEMANAGER_DATABASE_MAX_CONNECTIONS", "0")]
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()));
+
+        assert!(from_iter::<_, Config>(data).is_err());
     }
 }

--- a/app/filemanager/src/env.rs
+++ b/app/filemanager/src/env.rs
@@ -55,6 +55,8 @@ pub struct Config {
     pub(crate) access_key_secret_id: Option<String>,
     #[serde(rename = "filemanager_crawl_concurrency")]
     pub(crate) crawl_concurrency: usize,
+    #[serde(rename = "filemanager_database_max_connections")]
+    pub(crate) database_max_connections: u32,
 }
 
 /// Default presigned URL expiry time, 7 days.
@@ -62,6 +64,9 @@ pub const DEFAULT_PRESIGN_EXPIRY: Duration = Duration::days(7);
 
 /// Default maximum number of objects processed concurrently.
 pub const DEFAULT_CRAWL_CONCURRENCY: usize = 50;
+
+/// Default maximum number of database connections per Lambda execution environment.
+pub const DEFAULT_DATABASE_MAX_CONNECTIONS: u32 = 2;
 
 fn parse_limit<'de, D>(deserializer: D) -> result::Result<Option<u64>, D::Error>
 where
@@ -109,6 +114,7 @@ impl Default for Config {
             api_cors_allow_headers: vec![AUTHORIZATION.to_string()],
             access_key_secret_id: None,
             crawl_concurrency: DEFAULT_CRAWL_CONCURRENCY,
+            database_max_connections: DEFAULT_DATABASE_MAX_CONNECTIONS,
         }
     }
 }
@@ -215,6 +221,11 @@ impl Config {
         self.crawl_concurrency
     }
 
+    /// Get the maximum number of database connections per Lambda execution environment.
+    pub fn database_max_connections(&self) -> u32 {
+        self.database_max_connections
+    }
+
     /// Get the value from an optional, or else try and get a different value, unwrapping into a Result.
     pub fn value_or_else<T>(value: Option<T>, or_else: Option<T>) -> Result<T> {
         value
@@ -257,6 +268,7 @@ mod tests {
             ("FILEMANAGER_API_CORS_ALLOW_HEADERS", "Authorization,Accept"),
             ("FILEMANAGER_ACCESS_KEY_SECRET_ID", "id"),
             ("FILEMANAGER_CRAWL_CONCURRENCY", "100"),
+            ("FILEMANAGER_DATABASE_MAX_CONNECTIONS", "10"),
         ]
         .into_iter()
         .map(|(key, value)| (key.to_string(), value.to_string()));
@@ -286,6 +298,7 @@ mod tests {
                 api_cors_allow_headers: vec!["Authorization".to_string(), "Accept".to_string()],
                 access_key_secret_id: Some("id".to_string()),
                 crawl_concurrency: 100,
+                database_max_connections: 10,
             }
         )
     }

--- a/app/filemanager/src/env.rs
+++ b/app/filemanager/src/env.rs
@@ -53,10 +53,15 @@ pub struct Config {
     pub(crate) api_cors_allow_headers: Vec<String>,
     #[serde(rename = "filemanager_access_key_secret_id")]
     pub(crate) access_key_secret_id: Option<String>,
+    #[serde(rename = "filemanager_crawl_concurrency")]
+    pub(crate) crawl_concurrency: usize,
 }
 
 /// Default presigned URL expiry time, 7 days.
 pub const DEFAULT_PRESIGN_EXPIRY: Duration = Duration::days(7);
+
+/// Default maximum number of objects processed concurrently.
+pub const DEFAULT_CRAWL_CONCURRENCY: usize = 50;
 
 fn parse_limit<'de, D>(deserializer: D) -> result::Result<Option<u64>, D::Error>
 where
@@ -103,6 +108,7 @@ impl Default for Config {
             ],
             api_cors_allow_headers: vec![AUTHORIZATION.to_string()],
             access_key_secret_id: None,
+            crawl_concurrency: DEFAULT_CRAWL_CONCURRENCY,
         }
     }
 }
@@ -204,6 +210,11 @@ impl Config {
         self.access_key_secret_id.as_deref()
     }
 
+    /// Get the maximum number of objects processed concurrently.
+    pub fn crawl_concurrency(&self) -> usize {
+        self.crawl_concurrency
+    }
+
     /// Get the value from an optional, or else try and get a different value, unwrapping into a Result.
     pub fn value_or_else<T>(value: Option<T>, or_else: Option<T>) -> Result<T> {
         value
@@ -245,6 +256,7 @@ mod tests {
             ("FILEMANAGER_API_CORS_ALLOW_METHODS", "GET,POST"),
             ("FILEMANAGER_API_CORS_ALLOW_HEADERS", "Authorization,Accept"),
             ("FILEMANAGER_ACCESS_KEY_SECRET_ID", "id"),
+            ("FILEMANAGER_CRAWL_CONCURRENCY", "100"),
         ]
         .into_iter()
         .map(|(key, value)| (key.to_string(), value.to_string()));
@@ -272,7 +284,8 @@ mod tests {
                 ]),
                 api_cors_allow_methods: vec!["GET".to_string(), "POST".to_string()],
                 api_cors_allow_headers: vec!["Authorization".to_string(), "Accept".to_string()],
-                access_key_secret_id: Some("id".to_string())
+                access_key_secret_id: Some("id".to_string()),
+                crawl_concurrency: 100,
             }
         )
     }

--- a/app/filemanager/src/events/aws/collecter.rs
+++ b/app/filemanager/src/events/aws/collecter.rs
@@ -28,7 +28,7 @@ use aws_sdk_s3::types::StorageClass::Standard;
 use aws_sdk_s3::types::{Tag, Tagging};
 use chrono::{DateTime, Utc};
 use futures::TryFutureExt;
-use futures::future::join_all;
+use futures::stream::{self, StreamExt, TryStreamExt};
 use itertools::Itertools;
 use std::collections::HashSet;
 use std::str::FromStr;
@@ -556,22 +556,27 @@ impl<'a> Collecter<'a> {
         crawl_bucket: Option<String>,
         crawl_prefix: Option<String>,
     ) -> Result<FlatS3EventMessages> {
+        let concurrency = match config.crawl_concurrency() {
+            0 => usize::MAX,
+            n => n,
+        };
         let events = FlatS3EventMessages(
-            join_all(events.into_inner().into_iter().map(|event| async move {
-                // No need to run this unnecessarily on removed events.
-                match event.event_type {
-                    EventType::Deleted | EventType::Other => return Ok(event),
-                    _ => {}
-                };
+            stream::iter(events.into_inner())
+                .map(|event| async move {
+                    // No need to run this unnecessarily on removed events.
+                    match event.event_type {
+                        EventType::Deleted | EventType::Other => return Ok(event),
+                        _ => {}
+                    };
 
-                trace!(key = ?event.key, bucket = ?event.bucket, "updating event");
+                    trace!(key = ?event.key, bucket = ?event.bucket, "updating event");
 
-                let event = Self::head(client, event).await;
-                Self::tagging(config, client, database_client, event).await
-            }))
-            .await
-            .into_iter()
-            .collect::<Result<Vec<FlatS3EventMessage>>>()?,
+                    let event = Self::head(client, event).await;
+                    Self::tagging(config, client, database_client, event).await
+                })
+                .buffered(concurrency)
+                .try_collect::<Vec<FlatS3EventMessage>>()
+                .await?,
         );
 
         if let Some(crawl_bucket) = crawl_bucket {

--- a/app/filemanager/src/events/aws/collecter.rs
+++ b/app/filemanager/src/events/aws/collecter.rs
@@ -534,10 +534,7 @@ impl<'a> Collecter<'a> {
         crawl_bucket: Option<String>,
         crawl_prefix: Option<String>,
     ) -> Result<FlatS3EventMessages> {
-        let concurrency = match config.crawl_concurrency() {
-            0 => usize::MAX,
-            n => n,
-        };
+        let concurrency = config.crawl_concurrency().get();
 
         // Fetch the S3 head and tagging for each object concurrently.
         let events = stream::iter(events.into_inner())

--- a/app/filemanager/src/events/aws/collecter.rs
+++ b/app/filemanager/src/events/aws/collecter.rs
@@ -30,7 +30,8 @@ use chrono::{DateTime, Utc};
 use futures::TryFutureExt;
 use futures::stream::{self, StreamExt, TryStreamExt};
 use itertools::Itertools;
-use std::collections::HashSet;
+use sea_orm::prelude::Json;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use tracing::{trace, warn};
 use uuid::Uuid;
@@ -304,13 +305,13 @@ impl<'a> Collecter<'a> {
             .update_archive_status(archive_status.and_then(ArchiveStatus::from_aws))
     }
 
-    /// Gets S3 tags from objects.
+    /// Gets S3 tags from objects, generating and applying a new `ingest_id` tag if one is not
+    /// already present. Returns the updated event along with the `ingest_id` of a moved object.
     pub async fn tagging(
         config: &Config,
         client: &S3Client,
-        database_client: &database::Client,
         event: FlatS3EventMessage,
-    ) -> Result<FlatS3EventMessage> {
+    ) -> Result<(FlatS3EventMessage, Option<Uuid>)> {
         let tagging = client
             .get_object_tagging(&event.key, &event.bucket, &event.version_id)
             .inspect_err(|err| {
@@ -325,7 +326,7 @@ impl<'a> Collecter<'a> {
             .ok();
 
         let Some(tagging) = tagging else {
-            return Ok(event);
+            return Ok((event, None));
         };
 
         trace!(tagging = ?tagging, "received tagging output");
@@ -365,11 +366,12 @@ impl<'a> Collecter<'a> {
                     )
                 });
 
-            // Only add a ingest_id to the new record if the tagging was successful.
+            // Only add a ingest_id to the new record if the tagging was successful. New objects do
+            // not have an existing database record, so no attributes need to be looked up.
             return if result.is_ok() {
-                Ok(event.with_ingest_id(Some(ingest_id)))
+                Ok((event.with_ingest_id(Some(ingest_id)), None))
             } else {
-                Ok(event)
+                Ok((event, None))
             };
         };
 
@@ -382,36 +384,12 @@ impl<'a> Collecter<'a> {
             );
         });
         let Ok(ingest_id) = ingest_id else {
-            return Ok(event);
+            return Ok((event, None));
         };
 
-        // From here, the new record must be a valid, moved object.
-        let event = event.with_ingest_id(Some(ingest_id));
-
-        // Get the attributes from the old record to update the new record with.
-        let filter = S3ObjectsFilter {
-            ingest_id: vec![ingest_id].into(),
-            ..Default::default()
-        };
-        let moved_object =
-            ListQueryBuilder::<_, s3_object::Entity>::new(database_client.connection_ref())
-                .filter_all(filter, true, false)?
-                .one()
-                .await
-                .ok()
-                .flatten();
-
-        // Update the new record with the attributes if possible, or return the new record without
-        // the attributes if not possible.
-        if let Some(moved_object) = moved_object {
-            Ok(event.with_attributes(moved_object.attributes))
-        } else {
-            warn!(
-                "Ingester Warning for {} in {}: Object with ingest_id {} not found in database",
-                event.key, event.bucket, ingest_id
-            );
-            Ok(event)
-        }
+        // From here, the new record must be a valid, moved object. Its attributes are carried over
+        // from the existing record, which is looked up in a single batched query.
+        Ok((event.with_ingest_id(Some(ingest_id)), Some(ingest_id)))
     }
 
     /// Updates events that are crawls to take into account the existing database state.
@@ -560,23 +538,53 @@ impl<'a> Collecter<'a> {
             0 => usize::MAX,
             n => n,
         };
+
+        // Fetch the S3 head and tagging for each object concurrently.
+        let events = stream::iter(events.into_inner())
+            .map(|event| async move {
+                // No need to run this unnecessarily on removed events.
+                match event.event_type {
+                    EventType::Deleted | EventType::Other => return Ok((event, None)),
+                    _ => {}
+                };
+
+                trace!(key = ?event.key, bucket = ?event.bucket, "updating event");
+
+                let event = Self::head(client, event).await;
+                Self::tagging(config, client, event).await
+            })
+            .buffered(concurrency)
+            .try_collect::<Vec<(FlatS3EventMessage, Option<Uuid>)>>()
+            .await?;
+
+        // Look up the attributes of all moved objects in a single query.
+        let attributes = Self::moved_object_attributes(
+            database_client,
+            events.iter().filter_map(|(_, ingest_id)| *ingest_id).collect(),
+        )
+        .await?;
+
+        // Carry the looked-up attributes over to each moved object in memory.
         let events = FlatS3EventMessages(
-            stream::iter(events.into_inner())
-                .map(|event| async move {
-                    // No need to run this unnecessarily on removed events.
-                    match event.event_type {
-                        EventType::Deleted | EventType::Other => return Ok(event),
-                        _ => {}
+            events
+                .into_iter()
+                .map(|(event, ingest_id)| {
+                    let Some(ingest_id) = ingest_id else {
+                        return event;
                     };
 
-                    trace!(key = ?event.key, bucket = ?event.bucket, "updating event");
-
-                    let event = Self::head(client, event).await;
-                    Self::tagging(config, client, database_client, event).await
+                    match attributes.get(&ingest_id) {
+                        Some(attributes) => event.with_attributes(attributes.clone()),
+                        None => {
+                            warn!(
+                                "Ingester Warning for {} in {}: Object with ingest_id {} not found in database",
+                                event.key, event.bucket, ingest_id
+                            );
+                            event
+                        }
+                    }
                 })
-                .buffered(concurrency)
-                .try_collect::<Vec<FlatS3EventMessage>>()
-                .await?,
+                .collect(),
         );
 
         if let Some(crawl_bucket) = crawl_bucket {
@@ -584,6 +592,37 @@ impl<'a> Collecter<'a> {
         } else {
             Ok(events)
         }
+    }
+
+    /// Look up the attributes of moved objects from the database in a single batched query.
+    async fn moved_object_attributes(
+        database_client: &database::Client,
+        ingest_ids: Vec<Uuid>,
+    ) -> Result<HashMap<Uuid, Option<Json>>> {
+        if ingest_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        // Deduplicate so the query does not contain redundant conditions.
+        let ingest_ids = ingest_ids.into_iter().collect::<HashSet<_>>();
+        let filter = S3ObjectsFilter {
+            ingest_id: ingest_ids.into_iter().collect_vec().into(),
+            ..Default::default()
+        };
+        let moved_objects =
+            ListQueryBuilder::<_, s3_object::Entity>::new(database_client.connection_ref())
+                .filter_all(filter, true, false)?
+                .all()
+                .await?;
+
+        let mut attributes = HashMap::with_capacity(moved_objects.len());
+        for object in moved_objects {
+            if let Some(ingest_id) = object.ingest_id {
+                attributes.entry(ingest_id).or_insert(object.attributes);
+            }
+        }
+
+        Ok(attributes)
     }
 
     /// Get the number of records processed.

--- a/app/filemanager/src/events/aws/collecter.rs
+++ b/app/filemanager/src/events/aws/collecter.rs
@@ -560,7 +560,10 @@ impl<'a> Collecter<'a> {
         // Look up the attributes of all moved objects in a single query.
         let attributes = Self::moved_object_attributes(
             database_client,
-            events.iter().filter_map(|(_, ingest_id)| *ingest_id).collect(),
+            events
+                .iter()
+                .filter_map(|(_, ingest_id)| *ingest_id)
+                .collect(),
         )
         .await?;
 
@@ -934,6 +937,166 @@ pub(crate) mod tests {
             s3_object_results[1].get::<Option<Json>, _>("attributes"),
             Some(expected_attributes)
         );
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn tagging_with_move_distinct_ingest_ids(pool: PgPool) {
+        let config = Default::default();
+        let client = Client::from_pool(pool.clone());
+        let mut collecter = test_collecter(&config, &client).await;
+
+        let entries = EntriesBuilder::default()
+            .with_n(3)
+            .build(&client)
+            .await
+            .unwrap();
+        let ingest_id_0 = entries.s3_objects[0].ingest_id.unwrap();
+        let attributes_0 = entries.s3_objects[0].attributes.clone();
+        let ingest_id_2 = entries.s3_objects[2].ingest_id.unwrap();
+        let attributes_2 = entries.s3_objects[2].attributes.clone();
+        assert_ne!(ingest_id_0, ingest_id_2);
+        assert_ne!(attributes_0, attributes_2);
+
+        // Two incoming moved objects, each tagged with a different ingest id.
+        collecter.raw_events = FlatS3EventMessages(vec![
+            expected_s3_event_message().with_version_id(default_version_id()),
+            expected_s3_event_message()
+                .with_key("key1".to_string())
+                .with_version_id(default_version_id()),
+        ]);
+        collecter.client = mock_s3(&[
+            head_expectation(
+                "key".to_string(),
+                default_version_id(),
+                expected_head_object(),
+            ),
+            head_expectation(
+                "key1".to_string(),
+                default_version_id(),
+                expected_head_object(),
+            ),
+            get_tagging_expectation(
+                "key".to_string(),
+                default_version_id(),
+                expected_get_object_tagging(Some(ingest_id_0)),
+            ),
+            get_tagging_expectation(
+                "key1".to_string(),
+                default_version_id(),
+                expected_get_object_tagging(Some(ingest_id_2)),
+            ),
+        ]);
+
+        let result = collecter.collect().await.unwrap();
+        let EventSourceType::S3(events) = &result.event_type else {
+            panic!();
+        };
+
+        let by_key: HashMap<String, (Option<Uuid>, Option<Json>)> = events
+            .keys
+            .iter()
+            .cloned()
+            .zip(
+                events
+                    .ingest_ids
+                    .iter()
+                    .cloned()
+                    .zip(events.attributes.iter().cloned()),
+            )
+            .collect();
+
+        assert_eq!(by_key["key"], (Some(ingest_id_0), attributes_0));
+        assert_eq!(by_key["key1"], (Some(ingest_id_2), attributes_2));
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn tagging_with_move_not_in_database(pool: PgPool) {
+        let config = Default::default();
+        let client = Client::from_pool(pool.clone());
+        let mut collecter = test_collecter(&config, &client).await;
+
+        // A valid ingest_id tag that does not correspond to any database record.
+        let ingest_id = UuidGenerator::generate();
+
+        collecter.raw_events = FlatS3EventMessages(vec![
+            expected_s3_event_message().with_version_id(default_version_id()),
+        ]);
+        collecter.client = mock_s3(&[
+            head_expectation(
+                "key".to_string(),
+                default_version_id(),
+                expected_head_object(),
+            ),
+            get_tagging_expectation(
+                "key".to_string(),
+                default_version_id(),
+                expected_get_object_tagging(Some(ingest_id)),
+            ),
+        ]);
+
+        let result = collecter.collect().await.unwrap();
+        let EventSourceType::S3(events) = &result.event_type else {
+            panic!();
+        };
+
+        // The ingest_id from the tag is still applied, but since there is no matching database.
+        assert_eq!(events.ingest_ids[0], Some(ingest_id));
+        assert_eq!(events.attributes[0], None);
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn tagging_with_move_shared_ingest_id(pool: PgPool) {
+        let config = Default::default();
+        let client = Client::from_pool(pool.clone());
+        let mut collecter = test_collecter(&config, &client).await;
+
+        // A single database record whose ingest_id is shared by two objects.
+        let ingest_id = UuidGenerator::generate();
+        let entries = EntriesBuilder::default()
+            .with_ingest_id(ingest_id)
+            .with_n(1)
+            .build(&client)
+            .await
+            .unwrap();
+        let attributes = entries.s3_objects[0].attributes.clone();
+
+        collecter.raw_events = FlatS3EventMessages(vec![
+            expected_s3_event_message().with_version_id(default_version_id()),
+            expected_s3_event_message()
+                .with_key("key1".to_string())
+                .with_version_id(default_version_id()),
+        ]);
+        collecter.client = mock_s3(&[
+            head_expectation(
+                "key".to_string(),
+                default_version_id(),
+                expected_head_object(),
+            ),
+            head_expectation(
+                "key1".to_string(),
+                default_version_id(),
+                expected_head_object(),
+            ),
+            get_tagging_expectation(
+                "key".to_string(),
+                default_version_id(),
+                expected_get_object_tagging(Some(ingest_id)),
+            ),
+            get_tagging_expectation(
+                "key1".to_string(),
+                default_version_id(),
+                expected_get_object_tagging(Some(ingest_id)),
+            ),
+        ]);
+
+        let result = collecter.collect().await.unwrap();
+        let EventSourceType::S3(events) = &result.event_type else {
+            panic!();
+        };
+
+        // Both incoming objects share the same ingest_id.
+        assert_eq!(events.ingest_ids, vec![Some(ingest_id), Some(ingest_id)]);
+        assert_eq!(events.attributes, vec![attributes.clone(), attributes]);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]

--- a/app/filemanager/src/events/aws/inventory.rs
+++ b/app/filemanager/src/events/aws/inventory.rs
@@ -10,7 +10,7 @@ use aws_sdk_s3::types::InventoryFormat;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use csv::{ReaderBuilder, StringRecord, Trim};
 use flate2::read::MultiGzDecoder;
-use futures::future::join_all;
+use futures::stream::{self, StreamExt};
 use futures::{Stream, TryStreamExt};
 use orc_rust::ArrowReaderBuilder;
 use orc_rust::error::OrcError;
@@ -24,6 +24,7 @@ use std::result;
 
 use crate::clients::aws::s3::Client;
 use crate::database::entities::sea_orm_active_enums::Reason;
+use crate::env::DEFAULT_CRAWL_CONCURRENCY;
 use crate::error::Error::S3Error;
 use crate::error::{Error, Result};
 use crate::events::aws::message::{EventType::Created, default_version_id, quote_e_tag};
@@ -37,12 +38,22 @@ const DEFAULT_CSV_MANIFEST: &str =
 #[derive(Debug)]
 pub struct Inventory {
     client: Client,
+    concurrency: usize,
 }
 
 impl Inventory {
     /// Create a new inventory.
     pub fn new(client: Client) -> Self {
-        Self { client }
+        Self {
+            client,
+            concurrency: DEFAULT_CRAWL_CONCURRENCY,
+        }
+    }
+
+    /// Set the maximum number of manifest files fetched concurrently.
+    pub fn with_concurrency(mut self, concurrency: usize) -> Self {
+        self.concurrency = concurrency;
+        self
     }
 
     /// Create a new inventory with a default s3 client.
@@ -250,7 +261,11 @@ impl Inventory {
         };
 
         // TODO: consider streaming a file and reading records without placing them into memory first.
-        let inventories = join_all(manifest.files.iter().map(|file| async {
+        let concurrency = match self.concurrency {
+            0 => usize::MAX,
+            n => n,
+        };
+        let inventories = stream::iter(manifest.files.iter().map(|file| async {
             let body = self.get_object_bytes(&file.key, &bucket).await?;
 
             if let Some(checksum) = &file.md5_checksum {
@@ -260,9 +275,9 @@ impl Inventory {
             self.records_from_format(&manifest.file_format, body, manifest.file_schema.as_deref())
                 .await
         }))
-        .await
-        .into_iter()
-        .collect::<Result<Vec<_>>>()?
+        .buffered(concurrency)
+        .try_collect::<Vec<_>>()
+        .await?
         .into_iter()
         .flatten()
         .collect();

--- a/app/filemanager/src/events/aws/inventory.rs
+++ b/app/filemanager/src/events/aws/inventory.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::from_slice;
 use serde_with::{DisplayFromStr, serde_as};
 use std::io::{BufReader, Cursor, Read};
+use std::num::NonZeroUsize;
 use std::result;
 
 use crate::clients::aws::s3::Client;
@@ -38,7 +39,7 @@ const DEFAULT_CSV_MANIFEST: &str =
 #[derive(Debug)]
 pub struct Inventory {
     client: Client,
-    concurrency: usize,
+    concurrency: NonZeroUsize,
 }
 
 impl Inventory {
@@ -51,7 +52,7 @@ impl Inventory {
     }
 
     /// Set the maximum number of manifest files fetched concurrently.
-    pub fn with_concurrency(mut self, concurrency: usize) -> Self {
+    pub fn with_concurrency(mut self, concurrency: NonZeroUsize) -> Self {
         self.concurrency = concurrency;
         self
     }
@@ -261,10 +262,7 @@ impl Inventory {
         };
 
         // TODO: consider streaming a file and reading records without placing them into memory first.
-        let concurrency = match self.concurrency {
-            0 => usize::MAX,
-            n => n,
-        };
+        let concurrency = self.concurrency.get();
         let inventories = stream::iter(manifest.files.iter().map(|file| async {
             let body = self.get_object_bytes(&file.key, &bucket).await?;
 

--- a/app/filemanager/src/handlers/aws.rs
+++ b/app/filemanager/src/handlers/aws.rs
@@ -99,7 +99,7 @@ pub async fn ingest_s3_inventory(
         ));
     }
 
-    let inventory = Inventory::new(s3_client);
+    let inventory = Inventory::new(s3_client).with_concurrency(env_config.crawl_concurrency());
 
     let records = if let Some(manifest) = manifest {
         inventory.parse_manifest(manifest).await?

--- a/app/filemanager/src/routes/error.rs
+++ b/app/filemanager/src/routes/error.rs
@@ -13,6 +13,7 @@ use sea_orm::DbErr;
 use serde::{Deserialize, Serialize};
 use serde_qs::axum::QsQueryRejection;
 use thiserror::Error;
+use tracing::error;
 use utoipa::{IntoResponses, ToSchema};
 
 use crate::error::Error;
@@ -145,6 +146,10 @@ impl Display for ErrorStatusCode {
 
 impl IntoResponse for ErrorStatusCode {
     fn into_response(self) -> Response {
+        if let ErrorStatusCode::InternalServerError(err) = &self {
+            error!("internal server error: {err}");
+        }
+
         let response = match self {
             ErrorStatusCode::BadRequest(err) => (StatusCode::BAD_REQUEST, extract::Json(err)),
             ErrorStatusCode::Conflict(err) => (StatusCode::CONFLICT, extract::Json(err)),

--- a/infrastructure/stage/functions/api.ts
+++ b/infrastructure/stage/functions/api.ts
@@ -28,6 +28,7 @@ export class ApiFunction extends fn.Function {
         AWS_LAMBDA_HTTP_IGNORE_STAGE_IN_PATH: 'true',
         FILEMANAGER_ACCESS_KEY_SECRET_ID: props.accessKeySecretArn,
         FILEMANAGER_INGESTER_TAG_NAME: FILEMANAGER_INGEST_ID_TAG_NAME,
+        FILEMANAGER_DATABASE_MAX_CONNECTIONS: '5',
         ...props.environment,
       },
       ...props,


### PR DESCRIPTION
During crawls, the filemanager would previously query the database while also simultaneously calling `HeadObject` on S3. For a single crawl, it would use `join_all` to fetch potentially 1000s of objects while also waiting on the database to return results for attributes and the ingest id. This would open a lot of connections to S3, and eventually exhaust the Lambda file descriptors, which have a limit of 1024: https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html, leading to errors like:

```
Error: hyper_util::client::legacy::Error(Connect, ConnectError("tcp open error", Os { code: 24, kind: Uncategorized, message: "Too many open files" }))
```

I think the reason this occurred recently is because of https://github.com/OrcaBus/service-filemanager/pull/95, which changed `max_connections` from 10 to 2. This would effectively make the database component of the `join_all` sequential, while the `HeadObject` component is very parallel, resulting in the file descriptor limit being hit.

This PR therefore has a few changes to address this:
* The `join_all` has been replaced with a bounded stream, that only polls 50 connections to S3 at a single time, which is well below the limit.
* The database component which fetches attributes and ingest_ids is processed separately, and not tied to the `HeadObject`.
    * It's also been improved to only execute a single batched query, rather than individual queries, as previously each crawl object fetched attributes one at a time.
* I've also made these concurrency limits configurable use env variables, so they are easier to change if needed.
    * The ingest function has max_connections set to 2, which I think is correct, as it would never need more than that.
    * The API function has max_connections reverted back to 10, which is more generous for the crawl path.  